### PR TITLE
v0.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
 
       - run: npm ci
 
+      - run: npm run lint
+
       - run: npm run compile
 
       # Build .vsix package

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 *.vsix
 .vscode-test/
+.claude/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,8 +1,11 @@
 .vscode/**
 .vscode-test/**
+.github/**
 src/**
 node_modules/**
 .gitignore
 tsconfig.json
+AGENTS.md
+test-*.js
 **/*.ts
 **/*.map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Two source files. `extension.ts` owns all VS Code API interactions. `speechEngin
 
 ## Architecture
 
-The extension spawns a background PowerShell process using Windows `System.Speech.Recognition`. The process writes `READY` and `DETECTED:<phrase>` to stdout. The extension reads stdout, matches phrases, and fires VS Code commands.
+The extension spawns a background PowerShell process using Windows `System.Speech.Recognition` with a synchronous `Recognize()` polling loop. The process communicates via stdout using four protocols: `READY`, `DETECTED:<phrase>`, `ERROR:<message>`, and `DEBUG:<info>`. The extension reads stdout, matches phrases, and fires VS Code commands.
 
 On wake word detection, the PowerShell process is killed to release the microphone (handoff), then respawned after a cooldown. This ensures only one thing uses the mic at a time.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.2.0] - 2026-03-05
+
+### Added
+
+- Configurable confidence threshold (`wakeWord.confidenceThreshold`) — adjustable from 0.1 to 0.9 with safe clamping.
+- Automatic retry with exponential backoff when the speech engine crashes (up to 3 retries at 2s, 5s, 10s delays).
+- Non-Windows activation guard: commands register as stubs with an informational message on macOS/Linux.
+- Troubleshooting section in README with common problems and solutions.
+- `npm run lint` step added to the release CI workflow.
+
+### Changed
+
+- Speech engine switched from async `RecognizeAsync()` to synchronous `Recognize()` polling loop. The async approach crashed with exit code 2 when spawned from the VS Code extension host.
+- Error reporting from the PowerShell script now uses stdout (`ERROR:` prefix) instead of stderr to avoid PowerShell CLIXML wrapping issues.
+
+### Fixed
+
+- Grammar construction: each wake phrase is now added individually to `Choices` via a `foreach` loop instead of passing the array directly. The previous approach created a sequence grammar (all phrases as one utterance) instead of alternatives.
+- `deactivate()` no longer crashes on non-Windows platforms where `speechEngine` is not initialized.
+
+---
+
 ## [0.1.1] - 2026-03-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@
       <td>
         <a href="https://marketplace.visualstudio.com/items?itemName=analytics-in-motion.wake-word"><img src="https://img.shields.io/visual-studio-marketplace/v/analytics-in-motion.wake-word?label=Marketplace&color=blue" alt="VS Code Marketplace version"></a>&nbsp;
         <a href="https://open-vsx.org/extension/analytics-in-motion/wake-word"><img src="https://img.shields.io/open-vsx/v/analytics-in-motion/wake-word?label=Open%20VSX&color=blue" alt="Open VSX version"></a>&nbsp;
-        <a href="https://marketplace.visualstudio.com/items?itemName=analytics-in-motion.wake-word"><img src="https://img.shields.io/visual-studio-marketplace/i/analytics-in-motion.wake-word?label=Installs&color=blue" alt="VS Code Marketplace installs"></a>&nbsp;
+        <a href="https://marketplace.visualstudio.com/items?itemName=analytics-in-motion.wake-word"><img src="https://img.shields.io/visual-studio-marketplace/i/analytics-in-motion.wake-word?label=Marketplace%20Installs&color=blue" alt="VS Code Marketplace installs"></a>&nbsp;
+        <a href="https://open-vsx.org/extension/analytics-in-motion/wake-word"><img src="https://img.shields.io/open-vsx/dt/analytics-in-motion/wake-word?label=Open%20VSX%20Installs&color=blue" alt="Open VSX installs"></a>&nbsp;
         <a href="https://github.com/analyticsinmotion/wake-word/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="Apache 2.0 License"></a>&nbsp;
       </td>
     </tr>

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ All audio processing happens locally on your machine using Windows built-in spee
 
 1. Install the extension -- that's it, no other setup
 2. When VS Code opens, the extension starts listening on your microphone via Windows speech recognition
-3. The extension matches recognised words against your configured wake phrases using prefix matching
+3. The speech engine uses a constrained grammar to match recognised speech against your configured wake phrases
 4. If a phrase is detected with sufficient confidence, the extension **releases the mic** and fires the mapped command
 5. The target assistant (Claude, Copilot, etc.) takes over the microphone with no contention
 6. After a configurable cooldown, wake word listening resumes automatically
@@ -70,7 +70,7 @@ macOS and Linux support is planned for a future release.
 
 The first time the extension tries to listen, a modal dialog explains exactly what happens: continuous microphone use, fully local processing. You must click "Allow Microphone Listening" to proceed.
 
-If you decline, auto-start is disabled. You can re-enable any time via the status bar or command palette. Reset the consent prompt with **Wake Word: Reset Microphone Consent**.
+If you decline, listening does not start. You can enable it any time via the status bar or command palette, which will re-prompt for consent. Reset the consent prompt with **Wake Word: Reset Microphone Consent**.
 
 ## Wake Phrase Routing
 
@@ -117,7 +117,7 @@ Add your own phrases in `settings.json`. Any spoken English phrase works:
 }
 ```
 
-The speech engine uses Windows built-in dictation with prefix matching against your configured phrases.
+The speech engine uses a constrained grammar built from your configured phrases for accurate matching.
 
 ### The handoff
 
@@ -139,6 +139,7 @@ This ensures only one thing uses the mic at a time.
 | `wakeWord.cooldownSeconds` | `30` | Seconds to pause after handoff before resuming |
 | `wakeWord.enableOnStartup` | `true` | Start listening when VS Code opens |
 | `wakeWord.showNotificationOnDetection` | `true` | Show notification when wake phrase is heard |
+| `wakeWord.confidenceThreshold` | `0.3` | Minimum confidence score (0.1–0.9) for wake phrase detection |
 
 ## Commands
 
@@ -168,15 +169,26 @@ The extension spawns a background PowerShell process that uses `System.Speech.Re
 
 The process flow:
 
-1. Extension builds a dictation-based recognition loop with prefix matching for the configured wake phrases
+1. Extension builds a constrained grammar from the configured wake phrases
 2. The recognition script is passed to PowerShell via an encoded command
-3. PowerShell loads `System.Speech`, sets up a dictation grammar, and calls `Recognize()` in a loop
-4. Recognised text is matched against wake phrase prefixes; a match writes to stdout
+3. PowerShell loads `System.Speech`, builds a `Choices`/`GrammarBuilder` grammar, and enters a synchronous `Recognize()` polling loop
+4. Each recognition result above the confidence threshold is written to stdout
 5. The extension reads stdout and fires the corresponding VS Code command
 6. On pause (handoff), the PowerShell process is killed to release the microphone
 7. On resume, a new PowerShell process starts
 
 Zero runtime npm dependencies. Zero model downloads. The speech engine ships with Windows.
+
+## Troubleshooting
+
+| Problem | Solution |
+| --- | --- |
+| "Wake Word currently supports Windows only" | The extension requires Windows 10 or later. macOS and Linux support is planned. |
+| Engine starts but never detects phrases | Try lowering `wakeWord.confidenceThreshold` (e.g. `0.2`). Speak clearly and close to your microphone. |
+| Too many false positives | Raise `wakeWord.confidenceThreshold` (e.g. `0.5` or higher). Use longer, more distinctive wake phrases. |
+| "Failed to start speech engine" | Ensure your microphone is connected and not in use by another application. Check Windows sound settings. |
+| Status bar shows "Wake: Error" | Click the status bar item to retry. Check the Output panel for details. If the error persists, try **Wake Word: Reset Microphone Consent** and re-enable. |
+| Extension keeps restarting | The engine retries up to 3 times on crash with increasing delays. If it fails after 3 retries, check that your audio device is working. |
 
 ## Privacy
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wake-word",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wake-word",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for VS Code with customizable wake word. Fully local, zero config.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for VS Code with customizable wake word. Fully local, zero config.",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",
@@ -99,6 +99,13 @@
           "type": "boolean",
           "default": true,
           "description": "Show a brief notification when a wake phrase is detected."
+        },
+        "wakeWord.confidenceThreshold": {
+          "type": "number",
+          "default": 0.3,
+          "minimum": 0.1,
+          "maximum": 0.9,
+          "description": "Minimum confidence score (0.1 to 0.9) required to trigger a wake phrase. Lower values detect more but increase false positives."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ let resumeTimer: ReturnType<typeof setTimeout> | null = null;
 let speechEngine: SpeechEngine;
 let isActive = false;
 let isStarting = false;
+let isDevMode = false;
 
 // ── Default routes ──────────────────────────────────────────
 
@@ -30,6 +31,23 @@ const DEFAULT_ROUTES: WakePhrase[] = [
 // ── Activation ──────────────────────────────────────────────
 
 export function activate(context: vscode.ExtensionContext) {
+  isDevMode = context.extensionMode === vscode.ExtensionMode.Development;
+  console.log("[Wake Word] Activating, devMode:", isDevMode);
+
+  if (process.platform !== "win32") {
+    const notWindows = () =>
+      vscode.window.showInformationMessage(
+        "Wake Word currently supports Windows only."
+      );
+    context.subscriptions.push(
+      vscode.commands.registerCommand("wakeWord.enable", notWindows),
+      vscode.commands.registerCommand("wakeWord.disable", notWindows),
+      vscode.commands.registerCommand("wakeWord.toggle", notWindows),
+      vscode.commands.registerCommand("wakeWord.resetConsent", notWindows)
+    );
+    return;
+  }
+
   speechEngine = new SpeechEngine();
 
   // Wire up events from the speech engine
@@ -49,6 +67,14 @@ export function activate(context: vscode.ExtensionContext) {
   speechEngine.on("stopped", () => {
     isActive = false;
     setStatusBar("off");
+  });
+
+  speechEngine.on("debug", (info: string) => {
+    console.log("[Wake Word] Speech:", info);
+  });
+
+  speechEngine.on("warning", (msg: string) => {
+    console.warn("[Wake Word]", msg);
   });
 
   speechEngine.on("error", (err: Error) => {
@@ -115,8 +141,10 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-  stopListening();
-  speechEngine.dispose();
+  if (speechEngine) {
+    stopListening();
+    speechEngine.dispose();
+  }
 }
 
 // ── Consent ─────────────────────────────────────────────────
@@ -176,7 +204,8 @@ function startListening() {
     return;
   }
 
-  speechEngine.start(routes);
+  const threshold = config.get<number>("confidenceThreshold", 0.3);
+  speechEngine.start(routes, threshold, isDevMode);
 }
 
 function stopListening() {

--- a/src/speechEngine.ts
+++ b/src/speechEngine.ts
@@ -15,8 +15,8 @@ export interface WakePhrase {
  * via a PowerShell child process. No API keys, no model downloads,
  * no system dependencies beyond what ships with Windows.
  *
- * The engine uses a dictation grammar and matches recognised text
- * against the configured wake phrases using prefix matching.
+ * The engine uses a constrained grammar built from the configured
+ * wake phrases for accurate matching.
  */
 export class SpeechEngine extends EventEmitter {
   private process: ChildProcess | null = null;
@@ -24,6 +24,12 @@ export class SpeechEngine extends EventEmitter {
   private _isListening = false;
   private _isPaused = false;
   private _killedIntentionally = false;
+  private currentThreshold = 0.3;
+  private currentDebugMode = false;
+  private retryCount = 0;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly MAX_RETRIES = 3;
+  private static readonly RETRY_DELAYS = [2000, 5000, 10000];
 
   get isListening(): boolean {
     return this._isListening;
@@ -33,7 +39,7 @@ export class SpeechEngine extends EventEmitter {
     return this._isPaused;
   }
 
-  start(phrases: WakePhrase[]): void {
+  start(phrases: WakePhrase[], confidenceThreshold = 0.3, debugMode = false): void {
     if (this._isListening) {
       return;
     }
@@ -54,14 +60,19 @@ export class SpeechEngine extends EventEmitter {
 
     this._killedIntentionally = false;
     this.currentPhrases = phrases;
+    const safeThreshold = Math.max(0.1, Math.min(0.9, Number(confidenceThreshold) || 0.3));
+    this.currentThreshold = safeThreshold;
+    this.currentDebugMode = debugMode;
     const phraseStrings = phrases.map((p) => p.phrase.toLowerCase().trim());
-    const script = this.buildScript(phraseStrings);
+    const script = this.buildScript(phraseStrings, safeThreshold, debugMode);
     const encoded = Buffer.from(script, "utf16le").toString("base64");
 
-    this.process = spawn(
-      `${process.env.SystemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`,
-      ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded],
-      { stdio: ["ignore", "pipe", "pipe"], windowsHide: true }
+    const psPath = `${process.env.SystemRoot}\\System32\\WindowsPowerShell\\v1.0\\powershell.exe`;
+    const psArgs = ["-NoProfile", "-NonInteractive", "-EncodedCommand", encoded];
+    this.emit("debug", `Spawning: ${psPath} (args: ${psArgs.length}, encoded len: ${encoded.length}, SystemRoot: ${process.env.SystemRoot})`);
+
+    this.process = spawn(psPath, psArgs,
+      { stdio: ["ignore", "pipe", "pipe"] }
     );
 
     let stdoutBuffer = "";
@@ -78,7 +89,12 @@ export class SpeechEngine extends EventEmitter {
         if (trimmed === "READY") {
           this._isListening = true;
           this._isPaused = false;
+          this.retryCount = 0;
           this.emit("started");
+        } else if (trimmed.startsWith("DEBUG:")) {
+          this.emit("debug", trimmed.substring(6));
+        } else if (trimmed.startsWith("ERROR:")) {
+          this.emit("error", new Error(trimmed.substring(6)));
         } else if (trimmed.startsWith("DETECTED:")) {
           const detected = trimmed.substring(9).toLowerCase().trim();
           const match = phrases.find(
@@ -107,19 +123,42 @@ export class SpeechEngine extends EventEmitter {
       );
     });
 
-    this.process.on("exit", () => {
+    this.process.on("exit", (code) => {
       const wasListening = this._isListening;
       this._isListening = false;
       this.process = null;
 
-      // Ignore stderr from intentional kills (stop/pause)
-      if (!this._killedIntentionally && stderrBuffer.trim()) {
-        const msg = this.parseStderr(stderrBuffer);
-        this.emit("error", new Error(msg));
+      this.emit("debug", `Process exited: code=${code}, killed=${this._killedIntentionally}, stderr=${JSON.stringify(stderrBuffer.trim())}`);
+
+      // Ignore intentional kills (stop/pause)
+      if (this._killedIntentionally) {
+        if (wasListening && !this._isPaused) {
+          this.emit("stopped");
+        }
         return;
       }
 
-      // Only emit stopped if we were actively listening (not paused)
+      // Non-zero exit = crash. Retry or report error.
+      if (code !== 0) {
+        const stderrMsg = stderrBuffer.trim() ? this.parseStderr(stderrBuffer) : "";
+        const msg = stderrMsg || `exit code ${code}`;
+
+        if (this.retryCount < SpeechEngine.MAX_RETRIES) {
+          const delay = SpeechEngine.RETRY_DELAYS[this.retryCount];
+          this.retryCount++;
+          this.emit("warning", `Speech engine crashed: ${msg}. Retrying in ${delay / 1000}s (attempt ${this.retryCount}/${SpeechEngine.MAX_RETRIES})...`);
+          this.retryTimer = setTimeout(() => {
+            this.retryTimer = null;
+            this.start(this.currentPhrases, this.currentThreshold, this.currentDebugMode);
+          }, delay);
+          return;
+        }
+
+        this.emit("error", new Error(`${msg} (failed after ${SpeechEngine.MAX_RETRIES} retries)`));
+        return;
+      }
+
+      // Clean exit (code 0) while listening = unexpected stop
       if (wasListening && !this._isPaused) {
         this.emit("stopped");
       }
@@ -132,6 +171,8 @@ export class SpeechEngine extends EventEmitter {
     }
 
     this._isPaused = false;
+    this.retryCount = 0;
+    this.clearRetryTimer();
     this.killProcess();
     this._isListening = false;
     this.emit("stopped");
@@ -156,10 +197,11 @@ export class SpeechEngine extends EventEmitter {
     // Don't clear _isPaused here — start() will clear it via the
     // "started" event when the engine is actually ready. If start()
     // fails, we remain in the paused state.
-    this.start(this.currentPhrases);
+    this.start(this.currentPhrases, this.currentThreshold, this.currentDebugMode);
   }
 
   dispose(): void {
+    this.clearRetryTimer();
     this.stop();
     this.removeAllListeners();
   }
@@ -172,7 +214,14 @@ export class SpeechEngine extends EventEmitter {
     }
 
     // Fall back to raw text, stripping the CLIXML header
-    return raw.replace(/#< CLIXML\s*/g, "").trim() || "Unknown speech engine error";
+    return raw.replace(/#< CLIXML\s*/g, "").trim();
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
   }
 
   private killProcess(): void {
@@ -187,65 +236,45 @@ export class SpeechEngine extends EventEmitter {
     }
   }
 
-  private buildScript(phrases: string[]): string {
+  private buildScript(phrases: string[], confidenceThreshold: number, debugMode: boolean): string {
     const escaped = phrases.map((p) => "'" + p.replace(/'/g, "''") + "'");
 
     return `
-Add-Type -AssemblyName System.Speech
-
 try {
+    [Console]::Out.WriteLine("DEBUG:loading speech engine...")
+    [Console]::Out.Flush()
+    Add-Type -AssemblyName System.Speech
+
     $phrases = @(${escaped.join(", ")})
-
-    # Pre-compute a 2-char prefix from the main keyword in each phrase.
-    # "hey claude" -> keyword "claude" -> prefix "cl"
-    # "hey copilot" -> keyword "copilot" -> prefix "co"
-    # Matching: any recognized word starting with the prefix triggers.
-    $phrasePrefix = @{}
-    foreach ($p in $phrases) {
-        # Pick the longest word as the keyword (skips filler like "hey")
-        $keyword = ($p -split '\\s+') | Sort-Object Length -Descending | Select-Object -First 1
-        $phrasePrefix[$p] = $keyword.ToLower().Substring(0, [Math]::Min(2, $keyword.Length))
-    }
-
     $engine = New-Object System.Speech.Recognition.SpeechRecognitionEngine
-    $engine.LoadGrammar((New-Object System.Speech.Recognition.DictationGrammar))
     $engine.SetInputToDefaultAudioDevice()
+
+    $choices = New-Object System.Speech.Recognition.Choices
+    foreach ($p in $phrases) { $choices.Add($p) }
+    $grammar = New-Object System.Speech.Recognition.Grammar(
+        (New-Object System.Speech.Recognition.GrammarBuilder($choices))
+    )
+    $engine.LoadGrammar($grammar)
 
     [Console]::Out.WriteLine("READY")
     [Console]::Out.Flush()
 
+    [Console]::Out.WriteLine("DEBUG:entering sync recognize loop")
+    [Console]::Out.Flush()
     while ($true) {
-        try {
-            $result = $engine.Recognize([TimeSpan]::FromSeconds(5))
-            if ($result -ne $null -and $result.Confidence -ge 0.3) {
-                $text = $result.Text.ToLower()
-                $recWords = $text -split '\\s+'
-                $found = $false
-                foreach ($p in $phrases) {
-                    $prefix = $phrasePrefix[$p]
-                    if ($prefix -eq $null) { continue }
-                    foreach ($rw in $recWords) {
-                        if ($rw.StartsWith($prefix)) {
-                            [Console]::Out.WriteLine("DETECTED:" + $p)
-                            [Console]::Out.Flush()
-                            $found = $true
-                            break
-                        }
-                    }
-                    if ($found) { break }
-                }
+        $result = $engine.Recognize([TimeSpan]::FromSeconds(5))
+        if ($result -ne $null) {${debugMode ? `
+            [Console]::Out.WriteLine("DEBUG:" + $result.Text + "|" + $result.Confidence)
+            [Console]::Out.Flush()` : ""}
+            if ($result.Confidence -ge ${confidenceThreshold}) {
+                [Console]::Out.WriteLine("DETECTED:" + $result.Text.ToLower())
+                [Console]::Out.Flush()
             }
-        } catch [System.OperationCanceledException] {
-            break
-        } catch {
-            # Timeout or no match, continue listening
         }
     }
-
-    $engine.Dispose()
 } catch {
-    [Console]::Error.WriteLine($_.Exception.Message)
-    [Console]::Error.Flush()
+    [Console]::Out.WriteLine("ERROR:" + $_.Exception.Message)
+    [Console]::Out.Flush()
     exit 1
 }
 `;


### PR DESCRIPTION
### Added

- Configurable confidence threshold (`wakeWord.confidenceThreshold`) — adjustable from 0.1 to 0.9 with safe clamping.
- Automatic retry with exponential backoff when the speech engine crashes (up to 3 retries at 2s, 5s, 10s delays).
- Non-Windows activation guard: commands register as stubs with an informational message on macOS/Linux.
- Troubleshooting section in README with common problems and solutions.
- `npm run lint` step added to the release CI workflow.

### Changed

- Speech engine switched from async `RecognizeAsync()` to synchronous `Recognize()` polling loop. The async approach crashed with exit code 2 when spawned from the VS Code extension host.
- Error reporting from the PowerShell script now uses stdout (`ERROR:` prefix) instead of stderr to avoid PowerShell CLIXML wrapping issues.

### Fixed

- Grammar construction: each wake phrase is now added individually to `Choices` via a `foreach` loop instead of passing the array directly. The previous approach created a sequence grammar (all phrases as one utterance) instead of alternatives.
- `deactivate()` no longer crashes on non-Windows platforms where `speechEngine` is not initialized.