### PR TITLE
v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
-
-### Added
-<!-- Add new features here -->
-
-### Changed
-<!-- Add changed behavior here -->
+## [0.2.1] - 2026-03-06
 
 ### Fixed
-<!-- Add bug fixes here -->
 
-### Removed
-<!-- Add removals/deprecations here -->
+- Consent flow now uses `try-finally` to ensure `isStarting` flag is always reset, even if the dialog throws.
+- Removed duplicate `isActive` state tracking in favour of `speechEngine.isListening`.
+- `pause()` now clears pending retry timers to prevent unexpected restarts during mic handoff.
+- `resume()` resets the retry counter so a fresh session gets the full 3 retries.
+- `killProcess()` now removes all process listeners before nulling the reference, preventing listener accumulation across crash/retry cycles.
 
 ---
 
@@ -100,5 +96,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Auto-start on VS Code launch (after consent).
 - Windows 10/11 supported; macOS and Linux planned for a future release.
 - Published to VS Code Marketplace and Open VSX Registry.
+
+---
+
+## [Unreleased]
+
+### Added
+<!-- Add new features here -->
+
+### Changed
+<!-- Add changed behavior here -->
+
+### Fixed
+<!-- Add bug fixes here -->
+
+### Removed
+<!-- Add removals/deprecations here -->
 
 ---

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 <h3 align="center">Voice Activation for VS Code</h3>
 
 <!-- badges: start -->
+<!--
 <div align="center">
   <table>
     <tr>
@@ -19,6 +20,35 @@
         <a href="https://marketplace.visualstudio.com/items?itemName=analytics-in-motion.wake-word"><img src="https://img.shields.io/visual-studio-marketplace/i/analytics-in-motion.wake-word?label=Marketplace%20Installs&color=blue" alt="VS Code Marketplace installs"></a>&nbsp;
         <a href="https://open-vsx.org/extension/analytics-in-motion/wake-word"><img src="https://img.shields.io/open-vsx/dt/analytics-in-motion/wake-word?label=Open%20VSX%20Installs&color=blue" alt="Open VSX installs"></a>&nbsp;
         <a href="https://github.com/analyticsinmotion/wake-word/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="Apache 2.0 License"></a>&nbsp;
+      </td>
+    </tr>
+  </table>
+</div>
+-->
+<!-- badges: end -->
+
+<!-- badges: start -->
+<div align="center">
+  <table>
+    <tr>
+      <td><strong>Meta</strong></td>
+      <td>
+        <a href="https://github.com/analyticsinmotion/wake-word/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="Apache 2.0 License"></a>&nbsp;
+        <a href="https://github.com/analyticsinmotion"><img src="https://raw.githubusercontent.com/analyticsinmotion/.github/main/assets/images/analytics-in-motion-github-badge-rounded.svg" alt="Analytics in Motion"></a>&nbsp;
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Microsoft Marketplace</strong></td>
+      <td>
+        <a href="https://marketplace.visualstudio.com/items?itemName=analytics-in-motion.wake-word"><img src="https://img.shields.io/visual-studio-marketplace/v/analytics-in-motion.wake-word?label=Version&color=blue" alt="VS Code Marketplace version"></a>&nbsp;
+        <a href="https://marketplace.visualstudio.com/items?itemName=analytics-in-motion.wake-word"><img src="https://img.shields.io/visual-studio-marketplace/i/analytics-in-motion.wake-word?label=Installs&color=blue" alt="VS Code Marketplace installs"></a>&nbsp;
+      </td>
+    </tr>
+    <tr>
+      <td><strong>Open VSX Registry</strong></td>
+      <td>
+        <a href="https://open-vsx.org/extension/analytics-in-motion/wake-word"><img src="https://img.shields.io/open-vsx/v/analytics-in-motion/wake-word?label=Version&color=blue" alt="Open VSX version"></a>&nbsp;
+        <a href="https://open-vsx.org/extension/analytics-in-motion/wake-word"><img src="https://img.shields.io/open-vsx/dt/analytics-in-motion/wake-word?label=Installs&color=blue" alt="Open VSX installs"></a>&nbsp;
       </td>
     </tr>
   </table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wake-word",
-  "version": "0.1.2",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wake-word",
-      "version": "0.1.2",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for VS Code with customizable wake word. Fully local, zero config.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,6 @@ import { SpeechEngine, WakePhrase } from "./speechEngine";
 let statusBarItem: vscode.StatusBarItem;
 let resumeTimer: ReturnType<typeof setTimeout> | null = null;
 let speechEngine: SpeechEngine;
-let isActive = false;
 let isStarting = false;
 let isDevMode = false;
 
@@ -56,7 +55,6 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   speechEngine.on("started", () => {
-    isActive = true;
     setStatusBar("listening");
   });
 
@@ -65,7 +63,6 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   speechEngine.on("stopped", () => {
-    isActive = false;
     setStatusBar("off");
   });
 
@@ -80,7 +77,6 @@ export function activate(context: vscode.ExtensionContext) {
   speechEngine.on("error", (err: Error) => {
     console.error("[Wake Word]", err);
     vscode.window.showErrorMessage(`Wake Word error: ${err.message}`);
-    isActive = false;
     setStatusBar("error");
   });
 
@@ -103,7 +99,7 @@ export function activate(context: vscode.ExtensionContext) {
     ),
     vscode.commands.registerCommand("wakeWord.disable", () => stopListening()),
     vscode.commands.registerCommand("wakeWord.toggle", () => {
-      if (isActive || speechEngine.isPaused) {
+      if (speechEngine.isListening || speechEngine.isPaused) {
         stopListening();
       } else {
         handleConsentThenStart(context);
@@ -131,7 +127,7 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
       if (e.affectsConfiguration("wakeWord.routes")) {
-        if (isActive) {
+        if (speechEngine.isListening) {
           stopListening();
           handleConsentThenStart(context);
         }
@@ -154,7 +150,7 @@ const CONSENT_KEY = "wakeWord.userConsented";
 async function handleConsentThenStart(
   context: vscode.ExtensionContext
 ): Promise<void> {
-  if (isActive || isStarting) {
+  if (speechEngine.isListening || isStarting) {
     return;
   }
 
@@ -167,27 +163,29 @@ async function handleConsentThenStart(
 
   isStarting = true;
 
-  const choice = await vscode.window.showWarningMessage(
-    "Wake Word uses your microphone to listen for wake phrases " +
-      "whenever VS Code is open. All audio is processed locally on " +
-      "your machine using Windows built-in speech recognition. " +
-      "Nothing is recorded or transmitted.\n\n" +
-      "When a wake phrase is detected, the microphone is released " +
-      "so the target assistant can use it. Wake word listening " +
-      "resumes automatically after a cooldown period.\n\n" +
-      "You can disable this at any time from the status bar.",
-    { modal: true },
-    "Allow Microphone Listening",
-    "Not Now"
-  );
+  try {
+    const choice = await vscode.window.showWarningMessage(
+      "Wake Word uses your microphone to listen for wake phrases " +
+        "whenever VS Code is open. All audio is processed locally on " +
+        "your machine using Windows built-in speech recognition. " +
+        "Nothing is recorded or transmitted.\n\n" +
+        "When a wake phrase is detected, the microphone is released " +
+        "so the target assistant can use it. Wake word listening " +
+        "resumes automatically after a cooldown period.\n\n" +
+        "You can disable this at any time from the status bar.",
+      { modal: true },
+      "Allow Microphone Listening",
+      "Not Now"
+    );
 
-  isStarting = false;
-
-  if (choice === "Allow Microphone Listening") {
-    await context.globalState.update(CONSENT_KEY, true);
-    startListening();
-  } else {
-    setStatusBar("off");
+    if (choice === "Allow Microphone Listening") {
+      await context.globalState.update(CONSENT_KEY, true);
+      startListening();
+    } else {
+      setStatusBar("off");
+    }
+  } finally {
+    isStarting = false;
   }
 }
 
@@ -211,7 +209,6 @@ function startListening() {
 function stopListening() {
   clearResumeTimer();
   speechEngine.stop();
-  isActive = false;
   setStatusBar("off");
 }
 

--- a/src/speechEngine.ts
+++ b/src/speechEngine.ts
@@ -184,6 +184,7 @@ export class SpeechEngine extends EventEmitter {
     }
 
     this._isPaused = true;
+    this.clearRetryTimer();
     this.killProcess();
     this._isListening = false;
     this.emit("paused");
@@ -197,6 +198,7 @@ export class SpeechEngine extends EventEmitter {
     // Don't clear _isPaused here — start() will clear it via the
     // "started" event when the engine is actually ready. If start()
     // fails, we remain in the paused state.
+    this.retryCount = 0;
     this.start(this.currentPhrases, this.currentThreshold, this.currentDebugMode);
   }
 
@@ -227,6 +229,9 @@ export class SpeechEngine extends EventEmitter {
   private killProcess(): void {
     if (this.process) {
       this._killedIntentionally = true;
+      this.process.stdout?.removeAllListeners();
+      this.process.stderr?.removeAllListeners();
+      this.process.removeAllListeners();
       try {
         this.process.kill();
       } catch {


### PR DESCRIPTION
### Fixed

- Consent flow now uses `try-finally` to ensure `isStarting` flag is always reset, even if the dialog throws.
- Removed duplicate `isActive` state tracking in favour of `speechEngine.isListening`.
- `pause()` now clears pending retry timers to prevent unexpected restarts during mic handoff.
- `resume()` resets the retry counter so a fresh session gets the full 3 retries.
- `killProcess()` now removes all process listeners before nulling the reference, preventing listener accumulation across crash/retry cycles.