### PR TITLE
v0.3.0

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,6 +6,7 @@ node_modules/**
 .gitignore
 tsconfig.json
 AGENTS.md
+scripts/**
 test-*.js
 **/*.ts
 **/*.map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 npm install                # Install dependencies
 npm run compile            # Build TypeScript to dist/
 npm run watch              # Build in watch mode
-npm run lint               # Run ESLint (report only). Do not use --fix.
+npm run lint               # Run ESLint + SVG check on README.md. Do not use --fix.
 npm run package            # Build .vsix package
 ```
 
@@ -21,6 +21,8 @@ wake-word/
   src/
     extension.ts       # VS Code extension entry point, commands, status bar, consent flow
     speechEngine.ts    # SpeechEngine class, spawns PowerShell, manages mic lifecycle
+  scripts/
+    check-readme.js    # Lint-time check: blocks vsce-restricted SVGs in README.md
   dist/                # Compiled JS output (do not edit)
   .github/workflows/
     release.yml        # CI: build .vsix, publish to Marketplace and Open VSX
@@ -30,7 +32,7 @@ Two source files. `extension.ts` owns all VS Code API interactions. `speechEngin
 
 ## Architecture
 
-The extension spawns a background PowerShell process using Windows `System.Speech.Recognition` with a synchronous `Recognize()` polling loop. The process communicates via stdout using four protocols: `READY`, `DETECTED:<phrase>`, `ERROR:<message>`, and `DEBUG:<info>`. The extension reads stdout, matches phrases, and fires VS Code commands.
+The extension spawns a background PowerShell process using Windows `System.Speech.Recognition` with a synchronous `Recognize()` polling loop. The process communicates via stdout using four protocols: `READY`, `DETECTED:<phrase>|<confidence>`, `ERROR:<message>`, and `DEBUG:<info>`. The extension reads stdout, matches phrases, and fires VS Code commands. All events are logged to a dedicated "Wake Word" output channel.
 
 On wake word detection, the PowerShell process is killed to release the microphone (handoff), then respawned after a cooldown. This ensures only one thing uses the mic at a time.
 
@@ -72,6 +74,7 @@ Manual testing checklist:
 5. Status bar transitions to "Wake: Active" during handoff
 6. Status bar returns to "Wake: Listening" after cooldown
 7. Toggle, enable, disable, and reset consent commands all work
+8. Output panel shows "Wake Word" channel with timestamped logs
 
 ## Boundaries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.3.0] - 2026-03-06
+
+### Added
+
+- Dedicated "Wake Word" output channel in the Output panel for all logging (debug, warnings, errors, detections).
+- Startup diagnostics logged automatically: route count, threshold, OS, VS Code version.
+- "Show Log" action on error toasts — opens the output channel directly.
+- Dual logging: output channel always, debug console when running via F5 (dev mode).
+- Pause on focus loss (`wakeWord.pauseOnFocusLoss`) — pauses listening when VS Code loses focus, resumes on regain. Off by default.
+- Phrase aliases: `phrase` field now accepts a string or array of strings, mapping multiple trigger phrases to one command.
+- Per-route cooldown: optional `cooldownSeconds` on each route entry, overrides the global setting.
+- SVG guard in `npm run lint` — catches blocked SVG references in README.md before commit.
+
+### Changed
+
+- Speech engine protocol: `DETECTED:<phrase>` now includes confidence as `DETECTED:<phrase>|<confidence>`.
+- `npm run lint` now also runs `scripts/check-readme.js` to catch vsce-blocked SVGs.
+
+---
+
 ## [0.2.1] - 2026-03-06
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -148,6 +148,31 @@ Add your own phrases in `settings.json`. Any spoken English phrase works:
 
 The speech engine uses a constrained grammar built from your configured phrases for accurate matching.
 
+### Phrase aliases
+
+The `phrase` field accepts a string or an array of strings. Use arrays to map multiple trigger phrases to the same command:
+
+```json
+{
+  "label": "Claude",
+  "phrase": ["hey claude", "open claude"],
+  "command": "claude-vscode.focus"
+}
+```
+
+### Per-route cooldown
+
+Override the global cooldown for individual routes with `cooldownSeconds`:
+
+```json
+{
+  "label": "Terminal",
+  "phrase": "computer",
+  "command": "workbench.action.terminal.focus",
+  "cooldownSeconds": 10
+}
+```
+
 ### The handoff
 
 When a wake phrase is detected:
@@ -168,6 +193,7 @@ This ensures only one thing uses the mic at a time.
 | `wakeWord.cooldownSeconds` | `30` | Seconds to pause after handoff before resuming |
 | `wakeWord.enableOnStartup` | `true` | Start listening when VS Code opens |
 | `wakeWord.showNotificationOnDetection` | `true` | Show notification when wake phrase is heard |
+| `wakeWord.pauseOnFocusLoss` | `false` | Pause listening when VS Code loses focus, resume on regain |
 | `wakeWord.confidenceThreshold` | `0.3` | Minimum confidence score (0.1–0.9) for wake phrase detection |
 
 ## Commands
@@ -201,7 +227,7 @@ The process flow:
 1. Extension builds a constrained grammar from the configured wake phrases
 2. The recognition script is passed to PowerShell via an encoded command
 3. PowerShell loads `System.Speech`, builds a `Choices`/`GrammarBuilder` grammar, and enters a synchronous `Recognize()` polling loop
-4. Each recognition result above the confidence threshold is written to stdout
+4. Each recognition result above the confidence threshold is written to stdout as `DETECTED:<phrase>|<confidence>`
 5. The extension reads stdout and fires the corresponding VS Code command
 6. On pause (handoff), the PowerShell process is killed to release the microphone
 7. On resume, a new PowerShell process starts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wake-word",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wake-word",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for VS Code with customizable wake word. Fully local, zero config.",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",

--- a/package.json
+++ b/package.json
@@ -73,12 +73,29 @@
                 "description": "Human-readable name shown in notifications (e.g. \"Claude\")"
               },
               "phrase": {
-                "type": "string",
-                "description": "The spoken phrase to listen for, in plain English (e.g. \"hey claude\")"
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "description": "A single spoken phrase to listen for (e.g. \"hey claude\")"
+                  },
+                  {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "minItems": 1,
+                    "description": "Multiple phrases that trigger the same command (e.g. [\"hey claude\", \"open claude\"])"
+                  }
+                ],
+                "description": "Spoken phrase(s) to listen for. Use a string for one phrase or an array for multiple aliases."
               },
               "command": {
                 "type": "string",
                 "description": "VS Code command ID to execute (e.g. \"workbench.action.chat.open\")"
+              },
+              "cooldownSeconds": {
+                "type": "number",
+                "minimum": 5,
+                "maximum": 300,
+                "description": "Override the global cooldown for this route (seconds). Falls back to wakeWord.cooldownSeconds if not set."
               }
             }
           }
@@ -100,6 +117,11 @@
           "default": true,
           "description": "Show a brief notification when a wake phrase is detected."
         },
+        "wakeWord.pauseOnFocusLoss": {
+          "type": "boolean",
+          "default": false,
+          "description": "Pause wake word listening when VS Code loses focus and resume when it regains focus."
+        },
         "wakeWord.confidenceThreshold": {
           "type": "number",
           "default": 0.3,
@@ -114,7 +136,7 @@
     "vscode:prepublish": "npm run compile",
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "lint": "eslint src --ext ts",
+    "lint": "eslint src --ext ts && node scripts/check-readme.js",
     "package": "vsce package",
     "publish:vscode": "vsce publish",
     "publish:openvsx": "ovsx publish",

--- a/scripts/check-readme.js
+++ b/scripts/check-readme.js
@@ -1,0 +1,25 @@
+const s = require("fs").readFileSync("README.md", "utf8");
+const m = s.match(/https?:\/\/[^\s)"']+\.svg/gi);
+if (!m) {
+  console.log("README: no SVGs");
+  process.exit(0);
+}
+
+// Badge services that vsce allows
+const allowed = [
+  "img.shields.io",
+  "badge.fury.io",
+  "badges.gitter.im",
+  "travis-ci.org",
+  "ci.appveyor.com",
+  "david-dm.org",
+];
+
+const blocked = m.filter((url) => !allowed.some((host) => url.includes(host)));
+if (blocked.length > 0) {
+  console.error("SVGs in README.md (blocked by vsce):");
+  blocked.forEach((u) => console.error(" ", u));
+  process.exit(1);
+} else {
+  console.log("README: no blocked SVGs (" + m.length + " allowed badge(s))");
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,10 +2,12 @@ import * as vscode from "vscode";
 import { SpeechEngine, WakePhrase } from "./speechEngine";
 
 let statusBarItem: vscode.StatusBarItem;
+let outputChannel: vscode.OutputChannel;
 let resumeTimer: ReturnType<typeof setTimeout> | null = null;
 let speechEngine: SpeechEngine;
 let isStarting = false;
 let isDevMode = false;
+let isPausedByFocus = false;
 
 // ── Default routes ──────────────────────────────────────────
 
@@ -47,11 +49,14 @@ export function activate(context: vscode.ExtensionContext) {
     return;
   }
 
+  outputChannel = vscode.window.createOutputChannel("Wake Word");
+  context.subscriptions.push(outputChannel);
+
   speechEngine = new SpeechEngine();
 
   // Wire up events from the speech engine
-  speechEngine.on("detected", (phrase: WakePhrase) => {
-    onWakeWordDetected(phrase);
+  speechEngine.on("detected", (phrase: WakePhrase, confidence: number) => {
+    onWakeWordDetected(phrase, confidence);
   });
 
   speechEngine.on("started", () => {
@@ -67,16 +72,23 @@ export function activate(context: vscode.ExtensionContext) {
   });
 
   speechEngine.on("debug", (info: string) => {
-    console.log("[Wake Word] Speech:", info);
+    log("info", info);
   });
 
   speechEngine.on("warning", (msg: string) => {
-    console.warn("[Wake Word]", msg);
+    log("warn", msg);
   });
 
   speechEngine.on("error", (err: Error) => {
-    console.error("[Wake Word]", err);
-    vscode.window.showErrorMessage(`Wake Word error: ${err.message}`);
+    log("error", err.message);
+    vscode.window.showErrorMessage(
+      `Wake Word error: ${err.message}`,
+      "Show Log"
+    ).then((choice) => {
+      if (choice === "Show Log") {
+        outputChannel.show();
+      }
+    });
     setStatusBar("error");
   });
 
@@ -131,6 +143,26 @@ export function activate(context: vscode.ExtensionContext) {
           stopListening();
           handleConsentThenStart(context);
         }
+      }
+    })
+  );
+
+  // Pause when VS Code loses focus (opt-in)
+  context.subscriptions.push(
+    vscode.window.onDidChangeWindowState((state) => {
+      const config = vscode.workspace.getConfiguration("wakeWord");
+      if (!config.get<boolean>("pauseOnFocusLoss", false)) {
+        return;
+      }
+
+      if (!state.focused && speechEngine.isListening) {
+        isPausedByFocus = true;
+        speechEngine.pause();
+        log("info", "Paused: window lost focus");
+      } else if (state.focused && isPausedByFocus) {
+        isPausedByFocus = false;
+        speechEngine.resume();
+        log("info", "Resumed: window regained focus");
       }
     })
   );
@@ -189,6 +221,17 @@ async function handleConsentThenStart(
   }
 }
 
+// ── Logging ──────────────────────────────────────────────────
+
+function log(level: "info" | "warn" | "error", message: string) {
+  const timestamp = new Date().toISOString().substring(11, 23);
+  const line = `[${timestamp}] [${level.toUpperCase()}] ${message}`;
+  outputChannel.appendLine(line);
+  if (isDevMode) {
+    console.log("[Wake Word]", line);
+  }
+}
+
 // ── Core logic ──────────────────────────────────────────────
 
 function startListening() {
@@ -203,11 +246,14 @@ function startListening() {
   }
 
   const threshold = config.get<number>("confidenceThreshold", 0.3);
+  log("info", `Starting: ${routes.length} routes, threshold=${threshold}, devMode=${isDevMode}`);
+  log("info", `OS: ${process.platform} ${process.arch}, VS Code: ${vscode.version}`);
   speechEngine.start(routes, threshold, isDevMode);
 }
 
 function stopListening() {
   clearResumeTimer();
+  isPausedByFocus = false;
   speechEngine.stop();
   setStatusBar("off");
 }
@@ -217,9 +263,10 @@ function stopListening() {
 function buildRoutes(config: vscode.WorkspaceConfiguration): WakePhrase[] {
   const userRoutes = config.get<WakePhrase[]>("routes", []);
 
-  const validRoutes = userRoutes.filter(
-    (r) => r.phrase?.trim() && r.label?.trim() && r.command?.trim()
-  );
+  const validRoutes = userRoutes.filter((r) => {
+    const phrases = Array.isArray(r.phrase) ? r.phrase : [r.phrase];
+    return phrases.some((p) => p?.trim()) && r.label?.trim() && r.command?.trim();
+  });
 
   if (validRoutes.length > 0) {
     return validRoutes;
@@ -230,13 +277,16 @@ function buildRoutes(config: vscode.WorkspaceConfiguration): WakePhrase[] {
 
 // ── Wake word triggered ─────────────────────────────────────
 
-async function onWakeWordDetected(phrase: WakePhrase) {
+async function onWakeWordDetected(phrase: WakePhrase, confidence: number) {
+  log("info", `Detected: "${phrase.label}" (confidence: ${confidence.toFixed(2)})`);
+
   const config = vscode.workspace.getConfiguration("wakeWord");
   const showNotification = config.get<boolean>(
     "showNotificationOnDetection",
     true
   );
-  const cooldownSeconds = config.get<number>("cooldownSeconds", 30);
+  const globalCooldown = config.get<number>("cooldownSeconds", 30);
+  const cooldownSeconds = phrase.cooldownSeconds ?? globalCooldown;
 
   if (showNotification) {
     vscode.window.showInformationMessage(

--- a/src/speechEngine.ts
+++ b/src/speechEngine.ts
@@ -4,8 +4,9 @@ import * as os from "os";
 
 export interface WakePhrase {
   label: string;
-  phrase: string;
+  phrase: string | string[];
   command: string;
+  cooldownSeconds?: number;
 }
 
 /**
@@ -63,7 +64,7 @@ export class SpeechEngine extends EventEmitter {
     const safeThreshold = Math.max(0.1, Math.min(0.9, Number(confidenceThreshold) || 0.3));
     this.currentThreshold = safeThreshold;
     this.currentDebugMode = debugMode;
-    const phraseStrings = phrases.map((p) => p.phrase.toLowerCase().trim());
+    const phraseStrings = phrases.flatMap((p) => SpeechEngine.normalizePhrases(p.phrase));
     const script = this.buildScript(phraseStrings, safeThreshold, debugMode);
     const encoded = Buffer.from(script, "utf16le").toString("base64");
 
@@ -96,12 +97,15 @@ export class SpeechEngine extends EventEmitter {
         } else if (trimmed.startsWith("ERROR:")) {
           this.emit("error", new Error(trimmed.substring(6)));
         } else if (trimmed.startsWith("DETECTED:")) {
-          const detected = trimmed.substring(9).toLowerCase().trim();
-          const match = phrases.find(
-            (p) => p.phrase.toLowerCase().trim() === detected
+          const payload = trimmed.substring(9);
+          const sepIndex = payload.lastIndexOf("|");
+          const detected = (sepIndex >= 0 ? payload.substring(0, sepIndex) : payload).toLowerCase().trim();
+          const confidence = sepIndex >= 0 ? parseFloat(payload.substring(sepIndex + 1)) : 0;
+          const match = phrases.find((p) =>
+            SpeechEngine.normalizePhrases(p.phrase).includes(detected)
           );
           if (match) {
-            this.emit("detected", match);
+            this.emit("detected", match, isNaN(confidence) ? 0 : confidence);
           }
         }
       }
@@ -208,6 +212,11 @@ export class SpeechEngine extends EventEmitter {
     this.removeAllListeners();
   }
 
+  static normalizePhrases(phrase: string | string[]): string[] {
+    const arr = Array.isArray(phrase) ? phrase : [phrase];
+    return arr.map((p) => p.toLowerCase().trim()).filter((p) => p.length > 0);
+  }
+
   private parseStderr(raw: string): string {
     // Extract error text from PowerShell CLIXML wrapper
     const match = raw.match(/<S S="Error">(.+?)<\/S>/s);
@@ -272,7 +281,7 @@ try {
             [Console]::Out.WriteLine("DEBUG:" + $result.Text + "|" + $result.Confidence)
             [Console]::Out.Flush()` : ""}
             if ($result.Confidence -ge ${confidenceThreshold}) {
-                [Console]::Out.WriteLine("DETECTED:" + $result.Text.ToLower())
+                [Console]::Out.WriteLine("DETECTED:" + $result.Text.ToLower() + "|" + $result.Confidence)
                 [Console]::Out.Flush()
             }
         }


### PR DESCRIPTION
### Added

- Dedicated "Wake Word" output channel in the Output panel for all logging (debug, warnings, errors, detections).
- Startup diagnostics logged automatically: route count, threshold, OS, VS Code version.
- "Show Log" action on error toasts — opens the output channel directly.
- Dual logging: output channel always, debug console when running via F5 (dev mode).
- Pause on focus loss (`wakeWord.pauseOnFocusLoss`) — pauses listening when VS Code loses focus, resumes on regain. Off by default.
- Phrase aliases: `phrase` field now accepts a string or array of strings, mapping multiple trigger phrases to one command.
- Per-route cooldown: optional `cooldownSeconds` on each route entry, overrides the global setting.
- SVG guard in `npm run lint` — catches blocked SVG references in README.md before commit.

### Changed

- Speech engine protocol: `DETECTED:<phrase>` now includes confidence as `DETECTED:<phrase>|<confidence>`.
- `npm run lint` now also runs `scripts/check-readme.js` to catch vsce-blocked SVGs.