### PR TITLE
v0.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 *.vsix
 .vscode-test/
 .claude/
+prototype/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -3,6 +3,7 @@
 .github/**
 src/**
 node_modules/**
+prototype/**
 .gitignore
 tsconfig.json
 AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,13 @@ Press F5 in VS Code to launch the Extension Development Host for manual testing.
 ```text
 wake-word/
   src/
-    extension.ts       # VS Code extension entry point, commands, status bar, consent flow
-    speechEngine.ts    # SpeechEngine class, spawns PowerShell, manages mic lifecycle
+    extension.ts              # VS Code extension entry point, commands, status bar, consent flow
+    speechEngineInterface.ts  # ISpeechEngine interface (implemented by both engines)
+    windowsSpeechEngine.ts    # WindowsSpeechEngine — spawns PowerShell, Windows System.Speech
+    sherpaEngine.ts           # SherpaEngine — spawns audio-engine.js under system Node.js
+  engine/
+    audio-engine.js           # Child process: micstream mic capture + sherpa-onnx keyword spotting
+    package.json              # Engine dependencies (micstream, sherpa-onnx, sentencepiece-js)
   scripts/
     check-readme.js    # Lint-time check: blocks vsce-restricted SVGs in README.md
   dist/                # Compiled JS output (do not edit)
@@ -28,13 +33,17 @@ wake-word/
     release.yml        # CI: build .vsix, publish to Marketplace and Open VSX
 ```
 
-Two source files. `extension.ts` owns all VS Code API interactions. `speechEngine.ts` owns the PowerShell child process and speech recognition. Keep this separation clean.
+`extension.ts` owns all VS Code API interactions. Both engines implement `ISpeechEngine` — `windowsSpeechEngine.ts` for Windows, `sherpaEngine.ts` for cross-platform. `audio-engine.js` runs under system Node.js (not Electron) so native audio addons load correctly. Keep this separation clean.
 
 ## Architecture
 
-The extension spawns a background PowerShell process using Windows `System.Speech.Recognition` with a synchronous `Recognize()` polling loop. The process communicates via stdout using four protocols: `READY`, `DETECTED:<phrase>|<confidence>`, `ERROR:<message>`, and `DEBUG:<info>`. The extension reads stdout, matches phrases, and fires VS Code commands. All events are logged to a dedicated "Wake Word" output channel.
+The extension selects a speech engine via `createEngine()` and wires it with `wireEngine()`. Both engines communicate via stdout using four protocols: `READY`, `DETECTED:<phrase>|<confidence>`, `ERROR:<message>`, and `DEBUG:<info>`. The extension reads stdout, matches phrases, and fires VS Code commands. All events are logged to a dedicated "Wake Word" output channel.
 
-On wake word detection, the PowerShell process is killed to release the microphone (handoff), then respawned after a cooldown. This ensures only one thing uses the mic at a time.
+**WindowsSpeechEngine** spawns a PowerShell process using `System.Speech.Recognition` with a synchronous `Recognize()` polling loop. No model downloads; the engine ships with Windows.
+
+**SherpaEngine** spawns `engine/audio-engine.js` under system Node.js. The child uses `@analyticsinmotion/micstream` for mic capture and `sherpa-onnx` for keyword spotting. Config is sent as a JSON line to stdin. System Node.js is required because Electron cannot load native addons at the correct ABI.
+
+On wake word detection, the engine process is killed to release the microphone (handoff), then respawned after a cooldown. This ensures only one thing uses the mic at a time.
 
 **IMPORTANT**: The PowerShell process must use Windows PowerShell (`System32\WindowsPowerShell\v1.0\powershell.exe`), not PowerShell Core (`pwsh`). `System.Speech` is not available in PowerShell Core.
 
@@ -69,12 +78,14 @@ Manual testing checklist:
 
 1. F5 to launch Extension Development Host
 2. Consent dialog appears on first run
-3. Status bar shows "Wake: Listening" after consent
+3. Status bar shows "Wake: Listening" after consent; engine indicator shows active engine (Windows/Sherpa)
 4. Say a wake phrase, confirm detection notification appears
-5. Status bar transitions to "Wake: Active" during handoff
-6. Status bar returns to "Wake: Listening" after cooldown
+5. Status bar transitions to countdown (`Wake: 30s → Wake: 29s → ...`) during handoff
+6. Status bar returns to "Wake: Listening" after cooldown; target command fired correctly
 7. Toggle, enable, disable, and reset consent commands all work
 8. Output panel shows "Wake Word" channel with timestamped logs
+9. Change `wakeWord.engine` in Settings while listening — engine restarts immediately, engine indicator updates
+10. Change `wakeWord.engine` during cooldown — countdown continues, new engine starts when it expires
 
 ## Boundaries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,24 +12,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **Cross-platform speech engine** (SherpaEngine) using sherpa-onnx keyword spotting. Supports Windows, macOS, and Linux. Runs as a child process under system Node.js so native audio addons load against the correct Node.js ABI — no Electron conflicts.
+- **Cross-platform speech engine** (SherpaEngine) using sherpa-onnx keyword spotting. Supports Windows, macOS, and Linux. Runs as a child process under system Node.js so native audio addons load against the correct Node.js ABI, with no Electron conflicts.
 - **Cross-platform microphone capture** via `@analyticsinmotion/micstream` (PortAudio). This resolves a fundamental blocker: VS Code's Electron runtime cannot load native audio addons, so there was previously no way to capture microphone audio on macOS or Linux. Running micstream under system Node.js in the engine child process bypasses this entirely.
 - `wakeWord.engine` setting to select the speech engine: `auto` (platform default), `windows` (Windows System.Speech), or `sherpa` (sherpa-onnx, cross-platform). Defaults to `auto`.
 - `wakeWord.nodePath` setting to override the Node.js executable path used by SherpaEngine. Useful when Node.js is installed via nvm, fnm, or a non-standard location not on VS Code's PATH.
 - Engine indicator in the status bar showing the active engine (`Windows` or `Sherpa`) while listening. Click the indicator to open engine settings.
-- Changing `wakeWord.engine` or `wakeWord.nodePath` in Settings now takes effect immediately — the engine restarts without reloading the window.
+- Changing `wakeWord.engine` or `wakeWord.nodePath` in Settings now takes effect immediately; the engine restarts without reloading the window.
 - Status bar countdown during cooldown: after a wake phrase fires, the status bar shows a live second-by-second countdown (`Wake: 30s → Wake: 29s → ...`) instead of a static "Wake: Active" message. Gives clear feedback on how long until listening resumes.
 
 ### Changed
 
 - Countdown uses a clock icon (`$(clock)`) rather than the spinning sync icon. The spinning icon reset its CSS animation every second when the status bar text was updated, causing a visible jerk. The clock icon is static and appropriate for a timed countdown.
-- Documentation updated to be editor-neutral: "VS Code" replaced with "your editor" or "the editor" in settings descriptions, README subheading, and How It Works section. The extension works in Cursor, Windsurf, and other VS Code forks — the docs now reflect that. Technical content (platform requirements, command IDs, architecture) is unchanged.
+- Documentation updated to be editor-neutral: "VS Code" replaced with "your editor" or "the editor" in settings descriptions, README subheading, and How It Works section. The extension works in Cursor, Windsurf, and other VS Code forks. The docs now reflect that. Technical content (platform requirements, command IDs, architecture) is unchanged.
 - Both engines now implement a shared `ISpeechEngine` interface, enabling clean engine switching and shared event handling.
 
 ### Fixed
 
 - Switching the speech engine during an active cooldown no longer cancels the countdown or breaks subsequent detection. The countdown continues normally; the new engine starts when it expires.
-- Model download now follows HTTP redirects. GitHub release URLs return `302 → CDN` — downloads previously failed silently on first install.
+- Model download now follows HTTP redirects. GitHub release URLs return `302 → CDN`. Downloads previously failed silently on first install.
 
 ---
 
@@ -39,12 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dedicated "Wake Word" output channel in the Output panel for all logging (debug, warnings, errors, detections).
 - Startup diagnostics logged automatically: route count, threshold, OS, VS Code version.
-- "Show Log" action on error toasts — opens the output channel directly.
+- "Show Log" action on error toasts that opens the output channel directly.
 - Dual logging: output channel always, debug console when running via F5 (dev mode).
-- Pause on focus loss (`wakeWord.pauseOnFocusLoss`) — pauses listening when VS Code loses focus, resumes on regain. Off by default.
+- Pause on focus loss (`wakeWord.pauseOnFocusLoss`): pauses listening when VS Code loses focus, resumes on regain. Off by default.
 - Phrase aliases: `phrase` field now accepts a string or array of strings, mapping multiple trigger phrases to one command.
 - Per-route cooldown: optional `cooldownSeconds` on each route entry, overrides the global setting.
-- SVG guard in `npm run lint` — catches blocked SVG references in README.md before commit.
+- SVG guard in `npm run lint` that catches blocked SVG references in README.md before commit.
 
 ### Changed
 
@@ -69,7 +69,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Configurable confidence threshold (`wakeWord.confidenceThreshold`) — adjustable from 0.1 to 0.9 with safe clamping.
+- Configurable confidence threshold (`wakeWord.confidenceThreshold`), adjustable from 0.1 to 0.9 with safe clamping.
 - Automatic retry with exponential backoff when the speech engine crashes (up to 3 retries at 2s, 5s, 10s delays).
 - Non-Windows activation guard: commands register as stubs with an informational message on macOS/Linux.
 - Troubleshooting section in README with common problems and solutions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [0.4.0] - 2026-03-08
+## [0.4.0] - 2026-03-10
 
 ### Added
 
+- **Cross-platform speech engine** (SherpaEngine) using sherpa-onnx keyword spotting. Supports Windows, macOS, and Linux. Runs as a child process under system Node.js so native audio addons load against the correct Node.js ABI — no Electron conflicts.
+- **Cross-platform microphone capture** via `@analyticsinmotion/micstream` (PortAudio). This resolves a fundamental blocker: VS Code's Electron runtime cannot load native audio addons, so there was previously no way to capture microphone audio on macOS or Linux. Running micstream under system Node.js in the engine child process bypasses this entirely.
+- `wakeWord.engine` setting to select the speech engine: `auto` (platform default), `windows` (Windows System.Speech), or `sherpa` (sherpa-onnx, cross-platform). Defaults to `auto`.
+- `wakeWord.nodePath` setting to override the Node.js executable path used by SherpaEngine. Useful when Node.js is installed via nvm, fnm, or a non-standard location not on VS Code's PATH.
+- Engine indicator in the status bar showing the active engine (`Windows` or `Sherpa`) while listening. Click the indicator to open engine settings.
+- Changing `wakeWord.engine` or `wakeWord.nodePath` in Settings now takes effect immediately — the engine restarts without reloading the window.
 - Status bar countdown during cooldown: after a wake phrase fires, the status bar shows a live second-by-second countdown (`Wake: 30s → Wake: 29s → ...`) instead of a static "Wake: Active" message. Gives clear feedback on how long until listening resumes.
 
 ### Changed
 
 - Countdown uses a clock icon (`$(clock)`) rather than the spinning sync icon. The spinning icon reset its CSS animation every second when the status bar text was updated, causing a visible jerk. The clock icon is static and appropriate for a timed countdown.
 - Documentation updated to be editor-neutral: "VS Code" replaced with "your editor" or "the editor" in settings descriptions, README subheading, and How It Works section. The extension works in Cursor, Windsurf, and other VS Code forks — the docs now reflect that. Technical content (platform requirements, command IDs, architecture) is unchanged.
+- Both engines now implement a shared `ISpeechEngine` interface, enabling clean engine switching and shared event handling.
+
+### Fixed
+
+- Switching the speech engine during an active cooldown no longer cancels the countdown or breaks subsequent detection. The countdown continues normally; the new engine starts when it expires.
+- Model download now follows HTTP redirects. GitHub release URLs return `302 → CDN` — downloads previously failed silently on first install.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Countdown uses a clock icon (`$(clock)`) rather than the spinning sync icon. The spinning icon reset its CSS animation every second when the status bar text was updated, causing a visible jerk. The clock icon is static and appropriate for a timed countdown.
+- Documentation updated to be editor-neutral: "VS Code" replaced with "your editor" or "the editor" in settings descriptions, README subheading, and How It Works section. The extension works in Cursor, Windsurf, and other VS Code forks — the docs now reflect that. Technical content (platform requirements, command IDs, architecture) is unchanged.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.4.0] - 2026-03-08
+
+### Added
+
+- Status bar countdown during cooldown: after a wake phrase fires, the status bar shows a live second-by-second countdown (`Wake: 30s → Wake: 29s → ...`) instead of a static "Wake: Active" message. Gives clear feedback on how long until listening resumes.
+
+### Changed
+
+- Countdown uses a clock icon (`$(clock)`) rather than the spinning sync icon. The spinning icon reset its CSS animation every second when the status bar text was updated, causing a visible jerk. The clock icon is static and appropriate for a timed countdown.
+
+---
+
 ## [0.3.0] - 2026-03-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <br>
   Wake Word
 </h1>
-<h3 align="center">Voice Activation for VS Code</h3>
+<h3 align="center">Voice Activation for Code Editors</h3>
 
 <!-- badges: start -->
 <!--
@@ -90,7 +90,7 @@ All audio processing happens locally on your machine using Windows built-in spee
 ## How It Works
 
 1. Install the extension -- that's it, no other setup
-2. When VS Code opens, the extension starts listening on your microphone via Windows speech recognition
+2. When your editor opens, the extension starts listening on your microphone via Windows speech recognition
 3. The speech engine uses a constrained grammar to match recognised speech against your configured wake phrases
 4. If a phrase is detected with sufficient confidence, the extension **releases the mic** and fires the mapped command
 5. The target assistant (Claude, Copilot, etc.) takes over the microphone with no contention
@@ -102,7 +102,7 @@ All audio processing happens locally on your machine using Windows built-in spee
 
 Install directly from the [VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=analytics-in-motion.wake-word).
 
-Or from the command line:
+Or from the command line (VS Code only):
 
 ```bash
 code --install-extension analytics-in-motion.wake-word
@@ -216,9 +216,9 @@ This ensures only one thing uses the mic at a time.
 | --- | --- | --- |
 | `wakeWord.routes` | `[]` | Wake phrase routing table. Uses defaults if empty. |
 | `wakeWord.cooldownSeconds` | `30` | Seconds to pause after handoff before resuming |
-| `wakeWord.enableOnStartup` | `true` | Start listening when VS Code opens |
+| `wakeWord.enableOnStartup` | `true` | Start listening when the editor opens |
 | `wakeWord.showNotificationOnDetection` | `true` | Show notification when wake phrase is heard |
-| `wakeWord.pauseOnFocusLoss` | `false` | Pause listening when VS Code loses focus, resume on regain |
+| `wakeWord.pauseOnFocusLoss` | `false` | Pause listening when the editor loses focus, resume on regain |
 | `wakeWord.confidenceThreshold` | `0.3` | Minimum confidence score (0.1–0.9) for wake phrase detection |
 
 ## Commands
@@ -230,7 +230,7 @@ This ensures only one thing uses the mic at a time.
 
 ## Common command IDs
 
-Useful values for the `command` field in your routes:
+Useful values for the `command` field in your routes. Command IDs listed are for VS Code — Cursor and other editors may use different IDs for the same features.
 
 | Assistant / Feature | Command ID |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ All audio processing happens locally on your machine. Nothing is recorded or tra
 
 ## How It Works
 
-1. Install the extension — on Windows, that's all. On macOS/Linux, a local speech model (~17MB) is downloaded on first use and cached.
+1. Install the extension. On Windows, that's all. On macOS/Linux, a local speech model (~17MB) is downloaded on first use and cached.
 2. When your editor opens, the extension starts listening on your microphone
 3. The speech engine matches recognised speech against your configured wake phrases
 4. If a phrase is detected with sufficient confidence, the extension **releases the mic** and fires the mapped command
@@ -118,7 +118,7 @@ code --install-extension analytics-in-motion.wake-word
 
 | Platform | Requirement |
 | --- | --- |
-| Windows 10/11 | No additional software — uses built-in `System.Speech.Recognition` |
+| Windows 10/11 | No additional software. Uses built-in `System.Speech.Recognition` |
 | macOS | Node.js 18+ (for the speech engine child process) |
 | Linux | Node.js 18+ (for the speech engine child process) |
 
@@ -236,7 +236,7 @@ This ensures only one thing uses the mic at a time.
 
 ## Common command IDs
 
-Useful values for the `command` field in your routes. Command IDs listed are for VS Code — Cursor and other editors may use different IDs for the same features.
+Useful values for the `command` field in your routes. Command IDs listed are for VS Code. Cursor and other editors may use different IDs for the same features.
 
 | Assistant / Feature | Command ID |
 | --- | --- |
@@ -255,7 +255,7 @@ The extension selects a speech engine based on platform (or the `wakeWord.engine
 
 ### Windows engine (default on Windows)
 
-Spawns a PowerShell process using `System.Speech.Recognition.SpeechRecognitionEngine` — the same engine built into Windows. A constrained grammar is built from your configured phrases and passed via encoded command. Zero model downloads; the speech engine ships with Windows.
+Spawns a PowerShell process using `System.Speech.Recognition.SpeechRecognitionEngine`, the same engine built into Windows. A constrained grammar is built from your configured phrases and passed via encoded command. Zero model downloads; the speech engine ships with Windows.
 
 ### Sherpa engine (default on macOS/Linux, optional on Windows)
 
@@ -287,7 +287,7 @@ Zero runtime npm dependencies in the extension host. All native dependencies are
 
 ## Privacy
 
-All speech recognition runs locally on your machine — no audio data ever leaves your device. On Windows, speech is processed by the built-in `System.Speech.Recognition` engine in memory. On macOS and Linux, a local `sherpa-onnx` model processes audio in the engine child process. Nothing is recorded, stored, or transmitted.
+All speech recognition runs locally on your machine. No audio data ever leaves your device. On Windows, speech is processed by the built-in `System.Speech.Recognition` engine in memory. On macOS and Linux, a local `sherpa-onnx` model processes audio in the engine child process. Nothing is recorded, stored, or transmitted.
 
 ## Platform Support
 

--- a/README.md
+++ b/README.md
@@ -83,15 +83,15 @@ Say a wake phrase and the right AI assistant opens -- no clicking required.
 
 Say **"Hey Claude"** and Claude opens. Say **"Hey Copilot"** and Copilot opens. Say **"Computer"** and the terminal focuses. The extension handles the routing, pauses its own mic so the assistant can use it, then resumes listening when the voice session ends.
 
-**Zero config. No API keys. No accounts. No downloads. No system dependencies.** Install and go.
+**Zero config. No API keys. No accounts. No system dependencies.** Install and go.
 
-All audio processing happens locally on your machine using Windows built-in speech recognition. Nothing is recorded or transmitted.
+All audio processing happens locally on your machine. Nothing is recorded or transmitted.
 
 ## How It Works
 
-1. Install the extension -- that's it, no other setup
-2. When your editor opens, the extension starts listening on your microphone via Windows speech recognition
-3. The speech engine uses a constrained grammar to match recognised speech against your configured wake phrases
+1. Install the extension — on Windows, that's all. On macOS/Linux, a local speech model (~17MB) is downloaded on first use and cached.
+2. When your editor opens, the extension starts listening on your microphone
+3. The speech engine matches recognised speech against your configured wake phrases
 4. If a phrase is detected with sufficient confidence, the extension **releases the mic** and fires the mapped command
 5. The target assistant (Claude, Copilot, etc.) takes over the microphone with no contention
 6. After a configurable cooldown, wake word listening resumes automatically
@@ -116,9 +116,13 @@ code --install-extension analytics-in-motion.wake-word
 
 ### Prerequisites
 
-Windows 10 or later. The extension uses Windows built-in `System.Speech.Recognition` engine which ships with all modern Windows installations. No additional software is required.
+| Platform | Requirement |
+| --- | --- |
+| Windows 10/11 | No additional software — uses built-in `System.Speech.Recognition` |
+| macOS | Node.js 18+ (for the speech engine child process) |
+| Linux | Node.js 18+ (for the speech engine child process) |
 
-macOS and Linux support is planned for a future release.
+On macOS and Linux a local speech model (~17MB) is downloaded on first use and cached. If Node.js is installed via nvm or fnm and not on VS Code's PATH, set `wakeWord.nodePath` to the full path of your `node` executable.
 
 ## First Run Consent
 
@@ -206,7 +210,7 @@ When a wake phrase is detected:
 2. The target VS Code command fires (opening the assistant)
 3. The assistant's voice mode takes over the microphone with no contention
 4. After `wakeWord.cooldownSeconds` (default: 30), wake word listening resumes
-5. Status bar shows "Wake: Active" during handoff, then returns to "Wake: Listening"
+5. Status bar shows a live countdown (`Wake: 30s → Wake: 29s → ...`) during handoff, then returns to "Wake: Listening"
 
 This ensures only one thing uses the mic at a time.
 
@@ -220,6 +224,8 @@ This ensures only one thing uses the mic at a time.
 | `wakeWord.showNotificationOnDetection` | `true` | Show notification when wake phrase is heard |
 | `wakeWord.pauseOnFocusLoss` | `false` | Pause listening when the editor loses focus, resume on regain |
 | `wakeWord.confidenceThreshold` | `0.3` | Minimum confidence score (0.1–0.9) for wake phrase detection |
+| `wakeWord.engine` | `auto` | Speech engine: `auto` (platform default), `windows` (System.Speech), or `sherpa` (cross-platform) |
+| `wakeWord.nodePath` | `""` | Path to Node.js executable. Leave empty to auto-detect. Set this if the engine cannot find Node.js (macOS/Linux with nvm or fnm). |
 
 ## Commands
 
@@ -245,42 +251,51 @@ Useful values for the `command` field in your routes. Command IDs listed are for
 
 ## How It Works (Technical)
 
-The extension spawns a background PowerShell process that uses `System.Speech.Recognition.SpeechRecognitionEngine` to listen for wake phrases. This is the same speech engine built into Windows that powers Cortana and Windows Speech Recognition.
+The extension selects a speech engine based on platform (or the `wakeWord.engine` setting) and spawns it as a background child process. Both engines communicate via stdout using the same protocol: `READY`, `DETECTED:<phrase>|<confidence>`, `ERROR:<message>`, `DEBUG:<info>`.
 
-The process flow:
+### Windows engine (default on Windows)
 
-1. Extension builds a constrained grammar from the configured wake phrases
-2. The recognition script is passed to PowerShell via an encoded command
-3. PowerShell loads `System.Speech`, builds a `Choices`/`GrammarBuilder` grammar, and enters a synchronous `Recognize()` polling loop
-4. Each recognition result above the confidence threshold is written to stdout as `DETECTED:<phrase>|<confidence>`
-5. The extension reads stdout and fires the corresponding VS Code command
-6. On pause (handoff), the PowerShell process is killed to release the microphone
-7. On resume, a new PowerShell process starts
+Spawns a PowerShell process using `System.Speech.Recognition.SpeechRecognitionEngine` — the same engine built into Windows. A constrained grammar is built from your configured phrases and passed via encoded command. Zero model downloads; the speech engine ships with Windows.
 
-Zero runtime npm dependencies. Zero model downloads. The speech engine ships with Windows.
+### Sherpa engine (default on macOS/Linux, optional on Windows)
+
+Spawns `audio-engine.js` under **system Node.js** (not Electron). The child process uses `@analyticsinmotion/micstream` (PortAudio) for mic capture and `sherpa-onnx` for keyword spotting. Running under system Node.js is required because Electron's Node.js runtime cannot load native audio addons. A local speech model (~17MB) is downloaded to VS Code's global storage on first use and cached.
+
+### Shared flow
+
+1. Extension builds phrase list and spawns the engine process
+2. Engine writes `READY` when the mic is open
+3. Each detection above the confidence threshold is written to stdout as `DETECTED:<phrase>|<confidence>`
+4. The extension reads stdout and fires the corresponding command
+5. On handoff, the engine process is killed to release the microphone
+6. After the cooldown countdown, a new engine process starts
+
+Zero runtime npm dependencies in the extension host. All native dependencies are isolated in the `engine/` child process.
 
 ## Troubleshooting
 
 | Problem | Solution |
 | --- | --- |
-| "Wake Word currently supports Windows only" | The extension requires Windows 10 or later. macOS and Linux support is planned. |
 | Engine starts but never detects phrases | Try lowering `wakeWord.confidenceThreshold` (e.g. `0.2`). Speak clearly and close to your microphone. |
 | Too many false positives | Raise `wakeWord.confidenceThreshold` (e.g. `0.5` or higher). Use longer, more distinctive wake phrases. |
-| "Failed to start speech engine" | Ensure your microphone is connected and not in use by another application. Check Windows sound settings. |
+| "Failed to start speech engine" | Ensure your microphone is connected and not in use by another application. Check your system sound settings. |
 | Status bar shows "Wake: Error" | Click the status bar item to retry. Check the Output panel for details. If the error persists, try **Wake Word: Reset Microphone Consent** and re-enable. |
 | Extension keeps restarting | The engine retries up to 3 times on crash with increasing delays. If it fails after 3 retries, check that your audio device is working. |
+| "Could not find Node.js" (macOS/Linux) | Set `wakeWord.nodePath` to the full path of your `node` executable (e.g. `/opt/homebrew/bin/node`). Common when using nvm or fnm. |
+| Microphone access denied (macOS) | Open System Settings → Privacy & Security → Microphone and enable access for VS Code (or your editor). |
+| Model download fails | Check your internet connection. The model is ~17MB downloaded from GitHub. If behind a proxy, ensure HTTPS traffic to `github.com` is allowed. |
 
 ## Privacy
 
-All speech recognition runs locally via Windows built-in `System.Speech.Recognition`. No audio data leaves your machine. The microphone stream is processed in memory by the Windows speech engine and never written to disk.
+All speech recognition runs locally on your machine — no audio data ever leaves your device. On Windows, speech is processed by the built-in `System.Speech.Recognition` engine in memory. On macOS and Linux, a local `sherpa-onnx` model processes audio in the engine child process. Nothing is recorded, stored, or transmitted.
 
 ## Platform Support
 
-| Platform | Status |
-| --- | --- |
-| Windows 10/11 | Supported |
-| macOS | Planned |
-| Linux | Planned |
+| Platform | Status | Engine |
+| --- | --- | --- |
+| Windows 10/11 | Supported | Windows built-in System.Speech |
+| macOS | Supported | sherpa-onnx (requires Node.js 18+) |
+| Linux | Supported | sherpa-onnx (requires Node.js 18+) |
 
 ## Compatibility
 

--- a/engine/audio-engine.js
+++ b/engine/audio-engine.js
@@ -1,0 +1,234 @@
+'use strict';
+
+/**
+ * audio-engine.js — child process script for cross-platform wake word detection.
+ *
+ * Runs under system Node.js (not the Electron runtime) so that native addons
+ * load against the correct Node.js ABI.
+ *
+ * Protocol (stdout):
+ *   READY                        — KWS loaded, mic open, listening
+ *   DETECTED:<phrase>|<conf>     — keyword detected (phrase lowercase, conf 0–1)
+ *   ERROR:<msg>                  — fatal error
+ *   DEBUG:<msg>                  — diagnostic info
+ *
+ * Config: read from stdin as a single JSON line then stdin is closed.
+ *   { phrases: [{phrase: string, label: string}],
+ *     threshold: number,
+ *     modelDir: string,
+ *     debugMode: boolean }
+ *
+ * Stop: close stdin or send "stop\n" on stdin.
+ */
+
+// Resolve modules relative to this script's own node_modules,
+// not the caller's working directory.
+const path = require('path');
+const Module = require('module');
+const engineDir = path.dirname(__filename);
+const _resolveFilename = Module._resolveFilename;
+Module._resolveFilename = function(request, parent, isMain, options) {
+  try {
+    return _resolveFilename.call(this, request, parent, isMain, options);
+  } catch (e) {
+    // Try resolving from engine dir as fallback
+    const enginePath = path.join(engineDir, 'node_modules', request);
+    try {
+      return _resolveFilename.call(this, enginePath, parent, isMain, options);
+    } catch {
+      // ignore, rethrow original
+    }
+    throw e;
+  }
+};
+
+// Prepend engine/node_modules to search path
+require.main.paths.unshift(path.join(engineDir, 'node_modules'));
+
+let mic = null;
+let kws = null;
+let kwsStream = null;
+let stopping = false;
+
+function out(msg) {
+  process.stdout.write(msg + '\n');
+}
+
+function debug(msg) {
+  out('DEBUG:' + msg);
+}
+
+function fatal(msg) {
+  out('ERROR:' + msg);
+  process.exit(1);
+}
+
+async function main(config) {
+  const { phrases, threshold, modelDir, debugMode } = config;
+
+  if (debugMode) debug('audio-engine starting, modelDir=' + modelDir);
+
+  // Load sentencepiece for BPE tokenisation
+  const { SentencePieceProcessor } = require('sentencepiece-js');
+  const sherpa = require('sherpa-onnx');
+  const MicStream = require('@analyticsinmotion/micstream');
+
+  // Tokenise each phrase and build a lookup map: DECODED_UPPER → phrase string
+  const sp = new SentencePieceProcessor();
+  await sp.load(path.join(modelDir, 'bpe.model'));
+
+  // Build keyword string (one BPE-tokenised phrase per line) and reverse map
+  const phraseMap = {}; // "HEY CLAUDE" → "hey claude"
+  const keywordLines = [];
+
+  for (const p of phrases) {
+    const raw = Array.isArray(p.phrase) ? p.phrase : [p.phrase];
+    for (const r of raw) {
+      const upper = r.toUpperCase().trim();
+      const tokens = sp.encodePieces(upper);
+      const tokenStr = tokens.join(' ');
+      const decoded = tokens.map(t => t.startsWith('\u2581') ? ' ' + t.slice(1) : t).join('').trim();
+      if (decoded) {
+        phraseMap[decoded] = r.toLowerCase().trim();
+        keywordLines.push(tokenStr);
+        if (debugMode) debug('phrase: ' + r + ' -> tokens: ' + tokenStr + ' -> decoded: ' + decoded);
+      }
+    }
+  }
+
+  if (keywordLines.length === 0) {
+    fatal('No valid phrases to detect');
+    return;
+  }
+
+  const keywords = keywordLines.join('\n');
+
+  // Create KWS instance
+  if (debugMode) debug('loading sherpa-onnx KWS model...');
+  try {
+    kws = sherpa.createKws({
+      featConfig: { samplingRate: 16000, featureDim: 80 },
+      modelConfig: {
+        transducer: {
+          encoder: path.join(modelDir, 'encoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx'),
+          decoder: path.join(modelDir, 'decoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx'),
+          joiner:  path.join(modelDir, 'joiner-epoch-12-avg-2-chunk-16-left-64.int8.onnx'),
+        },
+        tokens: path.join(modelDir, 'tokens.txt'),
+        provider: 'cpu',
+        numThreads: 1,
+        modelingUnit: 'bpe',
+        bpeVocab: path.join(modelDir, 'bpe.model'),
+        debug: 0,
+      },
+      maxActivePaths: 4,
+      numTrailingBlanks: 1,
+      keywordsScore: 1.0,
+      keywordsThreshold: Math.max(0.1, Math.min(0.9, threshold || 0.25)),
+      keywords,
+    });
+  } catch (err) {
+    fatal('Failed to load KWS model: ' + err.message);
+    return;
+  }
+
+  kwsStream = kws.createStream();
+
+  // Open microphone
+  if (debugMode) debug('opening microphone...');
+  try {
+    mic = new MicStream({ sampleRate: 16000, channels: 1 });
+  } catch (err) {
+    fatal('Failed to open microphone: ' + err.message);
+    return;
+  }
+
+  mic.on('error', (err) => {
+    fatal('Microphone error: ' + err.message);
+  });
+
+  mic.on('data', (chunk) => {
+    if (stopping || !kws || !kwsStream) return;
+
+    // chunk is Int16 little-endian PCM — convert to Float32 in [-1, 1]
+    const samples = new Int16Array(chunk.buffer, chunk.byteOffset, chunk.length / 2);
+    const floats = new Float32Array(samples.length);
+    for (let i = 0; i < samples.length; i++) {
+      floats[i] = samples[i] / 32768.0;
+    }
+
+    kwsStream.acceptWaveform(16000, floats);
+
+    while (kws.isReady(kwsStream)) {
+      kws.decode(kwsStream);
+      const result = kws.getResult(kwsStream);
+      if (result.keyword !== '') {
+        const decodedKey = result.keyword.trim();
+        const phrase = phraseMap[decodedKey];
+        if (phrase) {
+          if (debugMode) debug('KWS result: ' + JSON.stringify(result));
+          out('DETECTED:' + phrase + '|1.0');
+        } else {
+          if (debugMode) debug('Unmatched KWS result: ' + JSON.stringify(result));
+        }
+        kws.reset(kwsStream);
+      }
+    }
+  });
+
+  out('READY');
+  if (debugMode) debug('mic open, listening for: ' + Object.values(phraseMap).join(', '));
+}
+
+function shutdown() {
+  if (stopping) return;
+  stopping = true;
+  if (mic) {
+    try { mic.stop(); } catch { /* ignore */ }
+    mic = null;
+  }
+  if (kwsStream) {
+    try { kwsStream.free(); } catch { /* ignore */ }
+    kwsStream = null;
+  }
+  if (kws) {
+    try { kws.free(); } catch { /* ignore */ }
+    kws = null;
+  }
+  process.exit(0);
+}
+
+// Read config from stdin (single JSON line)
+let stdinBuf = '';
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', (chunk) => {
+  stdinBuf += chunk;
+  const nl = stdinBuf.indexOf('\n');
+  if (nl !== -1) {
+    const line = stdinBuf.substring(0, nl).trim();
+    stdinBuf = stdinBuf.substring(nl + 1);
+    if (line === 'stop') {
+      shutdown();
+      return;
+    }
+    if (!line) return;
+    let config;
+    try {
+      config = JSON.parse(line);
+    } catch (e) {
+      fatal('Invalid config JSON: ' + e.message);
+      return;
+    }
+    main(config).catch((err) => fatal('Startup error: ' + err.message));
+  }
+});
+
+process.stdin.on('end', () => {
+  // stdin closed without a stop command — shut down cleanly
+  shutdown();
+});
+
+process.on('disconnect', shutdown);
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/engine/package-lock.json
+++ b/engine/package-lock.json
@@ -1,0 +1,74 @@
+{
+  "name": "wake-word-engine",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wake-word-engine",
+      "version": "1.0.0",
+      "dependencies": {
+        "@analyticsinmotion/micstream": "latest",
+        "sentencepiece-js": "latest",
+        "sherpa-onnx": "latest"
+      }
+    },
+    "node_modules/@analyticsinmotion/micstream": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@analyticsinmotion/micstream/-/micstream-0.4.0.tgz",
+      "integrity": "sha512-l+7xaKYwNAGbIxBR0icQHhPfIlIUs4aum8oNCBLftSa9c5/Zv7SCdxmqGQSm09AFEXHLOq//nD9dT0GWshywOA==",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "node-gyp-build": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/app-root-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
+      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
+      }
+    },
+    "node_modules/sentencepiece-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/sentencepiece-js/-/sentencepiece-js-1.1.0.tgz",
+      "integrity": "sha512-HN6teKCRO9tz37zbaNI3i+vMZ/JRWDt6kmZ7OVpzQv1jZHyYNmf5tE7CFpIYN86+y9TLB0cuscMdA3OHhT/MhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "app-root-path": "^3.1.0"
+      }
+    },
+    "node_modules/sherpa-onnx": {
+      "version": "1.12.28",
+      "resolved": "https://registry.npmjs.org/sherpa-onnx/-/sherpa-onnx-1.12.28.tgz",
+      "integrity": "sha512-PaOuTCUA/Vh5o3zcq+z3j1Zpv2VlP7iubOgYoVODDyeFDicRxjskiEQqERdWEcpQUi6vh47q3A63bS7Y9FRHNg==",
+      "license": "Apache-2.0"
+    }
+  }
+}

--- a/engine/package.json
+++ b/engine/package.json
@@ -5,8 +5,8 @@
   "private": true,
   "main": "audio-engine.js",
   "dependencies": {
-    "@analyticsinmotion/micstream": "latest",
-    "sentencepiece-js": "latest",
-    "sherpa-onnx": "latest"
+    "@analyticsinmotion/micstream": "0.4.0",
+    "sentencepiece-js": "1.1.0",
+    "sherpa-onnx": "1.12.28"
   }
 }

--- a/engine/package.json
+++ b/engine/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "wake-word-engine",
+  "version": "1.0.0",
+  "description": "Child process audio engine for Wake Word extension. Runs under system Node.js.",
+  "private": true,
+  "main": "audio-engine.js",
+  "dependencies": {
+    "@analyticsinmotion/micstream": "latest",
+    "sentencepiece-js": "latest",
+    "sherpa-onnx": "latest"
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wake-word",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wake-word",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wake-word",
   "displayName": "Wake Word",
-  "description": "Voice control for VS Code with customizable wake word. Fully local, zero config.",
+  "description": "Voice control for your editor with customizable wake word. Fully local, zero config.",
   "version": "0.4.0",
   "license": "Apache-2.0",
   "icon": "icon.png",
@@ -59,7 +59,7 @@
         "wakeWord.routes": {
           "type": "array",
           "default": [],
-          "description": "Wake phrase routing table. Each entry maps a spoken phrase to a VS Code command. If empty, default routes are used (Hey Copilot, Hey Claude, Computer).",
+          "description": "Wake phrase routing table. Each entry maps a spoken phrase to an editor command. If empty, default routes are used (Hey Copilot, Hey Claude, Computer).",
           "items": {
             "type": "object",
             "required": [
@@ -89,7 +89,7 @@
               },
               "command": {
                 "type": "string",
-                "description": "VS Code command ID to execute (e.g. \"workbench.action.chat.open\")"
+                "description": "Command ID to execute (e.g. \"workbench.action.chat.open\")"
               },
               "cooldownSeconds": {
                 "type": "number",
@@ -110,7 +110,7 @@
         "wakeWord.enableOnStartup": {
           "type": "boolean",
           "default": true,
-          "description": "Start listening automatically when VS Code opens."
+          "description": "Start listening automatically when the editor opens."
         },
         "wakeWord.showNotificationOnDetection": {
           "type": "boolean",
@@ -120,7 +120,7 @@
         "wakeWord.pauseOnFocusLoss": {
           "type": "boolean",
           "default": false,
-          "description": "Pause wake word listening when VS Code loses focus and resume when it regains focus."
+          "description": "Pause wake word listening when the editor loses focus and resume when it regains focus."
         },
         "wakeWord.confidenceThreshold": {
           "type": "number",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for VS Code with customizable wake word. Fully local, zero config.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,22 @@
           "minimum": 0.1,
           "maximum": 0.9,
           "description": "Minimum confidence score (0.1 to 0.9) required to trigger a wake phrase. Lower values detect more but increase false positives."
+        },
+        "wakeWord.nodePath": {
+          "type": "string",
+          "default": "",
+          "description": "Path to the Node.js executable. Leave empty to auto-detect. Set this if Wake Word cannot find Node.js (common with nvm or fnm). macOS and Linux only."
+        },
+        "wakeWord.engine": {
+          "type": "string",
+          "default": "auto",
+          "enum": ["auto", "windows", "sherpa"],
+          "enumDescriptions": [
+            "Use the best engine for your platform (Windows Speech on Windows, sherpa-onnx elsewhere).",
+            "Force Windows built-in System.Speech engine (Windows only).",
+            "Force sherpa-onnx keyword spotting engine (cross-platform, requires model download)."
+          ],
+          "description": "Speech engine to use. Leave on 'auto' unless testing a specific engine."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,15 @@
 import * as vscode from "vscode";
-import { SpeechEngine, WakePhrase } from "./speechEngine";
+import * as os from "os";
+import { WakePhrase, ISpeechEngine } from "./speechEngineInterface";
+import { WindowsSpeechEngine } from "./windowsSpeechEngine";
+import { SherpaEngine } from "./sherpaEngine";
 
 let statusBarItem: vscode.StatusBarItem;
+let engineBarItem: vscode.StatusBarItem;
 let outputChannel: vscode.OutputChannel;
 let countdownTimer: ReturnType<typeof setInterval> | null = null;
 let countdownRemaining = 0;
-let speechEngine: SpeechEngine;
+let speechEngine: ISpeechEngine;
 let isStarting = false;
 let isDevMode = false;
 let isPausedByFocus = false;
@@ -30,70 +34,57 @@ const DEFAULT_ROUTES: WakePhrase[] = [
   },
 ];
 
-// ── Activation ──────────────────────────────────────────────
+// ── Engine factory ───────────────────────────────────────────
 
-export function activate(context: vscode.ExtensionContext) {
-  isDevMode = context.extensionMode === vscode.ExtensionMode.Development;
-  console.log("[Wake Word] Activating, devMode:", isDevMode);
+function createEngine(context: vscode.ExtensionContext): ISpeechEngine {
+  const config = vscode.workspace.getConfiguration("wakeWord");
+  const nodePath = config.get<string>("nodePath", "");
+  const engineOverride = config.get<string>("engine", "auto");
 
-  if (process.platform !== "win32") {
-    const notWindows = () =>
-      vscode.window.showInformationMessage(
-        "Wake Word currently supports Windows only."
-      );
-    context.subscriptions.push(
-      vscode.commands.registerCommand("wakeWord.enable", notWindows),
-      vscode.commands.registerCommand("wakeWord.disable", notWindows),
-      vscode.commands.registerCommand("wakeWord.toggle", notWindows),
-      vscode.commands.registerCommand("wakeWord.resetConsent", notWindows)
-    );
-    return;
+  if (engineOverride === "sherpa") {
+    return new SherpaEngine(context, nodePath);
   }
+  if (engineOverride === "windows" || (engineOverride === "auto" && os.platform() === "win32")) {
+    return new WindowsSpeechEngine();
+  }
+  return new SherpaEngine(context, nodePath);
+}
 
-  outputChannel = vscode.window.createOutputChannel("Wake Word");
-  context.subscriptions.push(outputChannel);
+// ── Engine wiring ────────────────────────────────────────────
 
-  speechEngine = new SpeechEngine();
-
-  // Wire up events from the speech engine
-  speechEngine.on("detected", (phrase: WakePhrase, confidence: number) => {
+function wireEngine(engine: ISpeechEngine): void {
+  engine.on("detected", (phrase: WakePhrase, confidence: number) => {
     onWakeWordDetected(phrase, confidence);
   });
-
-  speechEngine.on("started", () => {
-    setStatusBar("listening");
-  });
-
-  speechEngine.on("paused", () => {
-    setStatusBar("handed-off");
-  });
-
-  speechEngine.on("stopped", () => {
-    setStatusBar("off");
-  });
-
-  speechEngine.on("debug", (info: string) => {
-    log("info", info);
-  });
-
-  speechEngine.on("warning", (msg: string) => {
-    log("warn", msg);
-  });
-
-  speechEngine.on("error", (err: Error) => {
+  engine.on("started", () => setStatusBar("listening"));
+  engine.on("paused", () => setStatusBar("handed-off"));
+  engine.on("stopped", () => setStatusBar("off"));
+  engine.on("debug", (info: string) => log("info", info));
+  engine.on("warning", (msg: string) => log("warn", msg));
+  engine.on("error", (err: Error) => {
     log("error", err.message);
-    vscode.window.showErrorMessage(
-      `Wake Word error: ${err.message}`,
-      "Show Log"
-    ).then((choice) => {
+    vscode.window.showErrorMessage(`Wake Word error: ${err.message}`, "Show Log").then((choice) => {
       if (choice === "Show Log") {
         outputChannel.show();
       }
     });
     setStatusBar("error");
   });
+}
 
-  // Status bar indicator
+// ── Activation ──────────────────────────────────────────────
+
+export function activate(context: vscode.ExtensionContext) {
+  isDevMode = context.extensionMode === vscode.ExtensionMode.Development;
+  console.log("[Wake Word] Activating, devMode:", isDevMode);
+
+  outputChannel = vscode.window.createOutputChannel("Wake Word");
+  context.subscriptions.push(outputChannel);
+
+  speechEngine = createEngine(context);
+  wireEngine(speechEngine);
+
+  // Status bar indicators
   statusBarItem = vscode.window.createStatusBarItem(
     "wakeWord.status",
     vscode.StatusBarAlignment.Right,
@@ -101,9 +92,26 @@ export function activate(context: vscode.ExtensionContext) {
   );
   statusBarItem.name = "Wake Word Status";
   statusBarItem.command = "wakeWord.toggle";
+  context.subscriptions.push(statusBarItem);
+
+  engineBarItem = vscode.window.createStatusBarItem(
+    "wakeWord.engine",
+    vscode.StatusBarAlignment.Right,
+    99
+  );
+  engineBarItem.name = "Wake Word Engine";
+  engineBarItem.tooltip = "Active speech engine. Click to change.";
+  context.subscriptions.push(engineBarItem);
+  context.subscriptions.push(
+    vscode.commands.registerCommand("wakeWord.openEngineSetting", () => {
+      vscode.commands.executeCommand("workbench.action.openSettings", "wakeWord.engine");
+    })
+  );
+  engineBarItem.command = "wakeWord.openEngineSetting";
+
+  // Both items created — safe to call setStatusBar now
   setStatusBar("off");
   statusBarItem.show();
-  context.subscriptions.push(statusBarItem);
 
   // Register commands
   context.subscriptions.push(
@@ -139,11 +147,30 @@ export function activate(context: vscode.ExtensionContext) {
   // Re-init when settings change
   context.subscriptions.push(
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration("wakeWord.routes")) {
-        if (speechEngine.isListening) {
-          stopListening();
-          handleConsentThenStart(context);
+      const engineChanged =
+        e.affectsConfiguration("wakeWord.engine") ||
+        e.affectsConfiguration("wakeWord.nodePath");
+
+      if (engineChanged) {
+        const wasListening = speechEngine.isListening;
+        const cooldownActive = countdownTimer !== null;
+        isPausedByFocus = false;
+        speechEngine.dispose();
+        speechEngine = createEngine(context);
+        wireEngine(speechEngine);
+        log("info", "Engine switched due to settings change");
+        updateEngineIndicator(cooldownActive);
+        if (cooldownActive) {
+          log("info", "Engine switched during cooldown — will start when cooldown expires");
+        } else if (wasListening) {
+          startListening();
         }
+        return;
+      }
+
+      if (e.affectsConfiguration("wakeWord.routes") && speechEngine.isListening) {
+        stopListening();
+        handleConsentThenStart(context);
       }
     })
   );
@@ -199,9 +226,8 @@ async function handleConsentThenStart(
   try {
     const choice = await vscode.window.showWarningMessage(
       "Wake Word uses your microphone to listen for wake phrases " +
-        "whenever VS Code is open. All audio is processed locally on " +
-        "your machine using Windows built-in speech recognition. " +
-        "Nothing is recorded or transmitted.\n\n" +
+        "whenever the editor is open. All audio is processed locally on " +
+        "your machine. Nothing is recorded or transmitted.\n\n" +
         "When a wake phrase is detected, the microphone is released " +
         "so the target assistant can use it. Wake word listening " +
         "resumes automatically after a cooldown period.\n\n" +
@@ -347,7 +373,11 @@ function scheduleResume(seconds: number) {
 
 function resumeListening() {
   clearResumeTimer();
-  speechEngine.resume();
+  if (speechEngine.isPaused) {
+    speechEngine.resume();
+  } else {
+    startListening();
+  }
 }
 
 function clearResumeTimer() {
@@ -360,18 +390,30 @@ function clearResumeTimer() {
 
 // ── Status bar ──────────────────────────────────────────────
 
+function updateEngineIndicator(visible: boolean): void {
+  if (!visible) {
+    engineBarItem.hide();
+    return;
+  }
+  const label = speechEngine instanceof SherpaEngine ? "Sherpa" : "Windows";
+  engineBarItem.text = `$(gear) ${label}`;
+  engineBarItem.show();
+}
+
 function setStatusBar(state: "off" | "listening" | "handed-off" | "error") {
   switch (state) {
     case "off":
       statusBarItem.text = "$(mic-off) Wake: Off";
       statusBarItem.tooltip = "Click to enable wake word listening";
       statusBarItem.backgroundColor = undefined;
+      updateEngineIndicator(false);
       break;
     case "listening":
       statusBarItem.text = "$(mic) Wake: Listening";
       statusBarItem.tooltip =
         "Listening for wake words... Click to disable";
       statusBarItem.backgroundColor = undefined;
+      updateEngineIndicator(true);
       break;
     case "handed-off":
       statusBarItem.text = "$(mic-filled) Wake: Active";
@@ -380,6 +422,7 @@ function setStatusBar(state: "off" | "listening" | "handed-off" | "error") {
       statusBarItem.backgroundColor = new vscode.ThemeColor(
         "statusBarItem.warningBackground"
       );
+      updateEngineIndicator(true);
       break;
     case "error":
       statusBarItem.text = "$(error) Wake: Error";
@@ -387,6 +430,7 @@ function setStatusBar(state: "off" | "listening" | "handed-off" | "error") {
       statusBarItem.backgroundColor = new vscode.ThemeColor(
         "statusBarItem.errorBackground"
       );
+      updateEngineIndicator(false);
       break;
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,8 @@ import { SpeechEngine, WakePhrase } from "./speechEngine";
 
 let statusBarItem: vscode.StatusBarItem;
 let outputChannel: vscode.OutputChannel;
-let resumeTimer: ReturnType<typeof setTimeout> | null = null;
+let countdownTimer: ReturnType<typeof setInterval> | null = null;
+let countdownRemaining = 0;
 let speechEngine: SpeechEngine;
 let isStarting = false;
 let isDevMode = false;
@@ -321,11 +322,27 @@ async function onWakeWordDetected(phrase: WakePhrase, confidence: number) {
 
 function scheduleResume(seconds: number) {
   clearResumeTimer();
+  countdownRemaining = seconds;
 
-  resumeTimer = setTimeout(() => {
-    resumeTimer = null;
-    resumeListening();
-  }, seconds * 1000);
+  statusBarItem.text = `$(clock) Wake: ${countdownRemaining}s`;
+  statusBarItem.tooltip = "Mic handed off to assistant. Resuming soon.";
+  statusBarItem.backgroundColor = new vscode.ThemeColor(
+    "statusBarItem.warningBackground"
+  );
+
+  countdownTimer = setInterval(() => {
+    countdownRemaining--;
+
+    if (countdownRemaining <= 0) {
+      clearResumeTimer();
+      resumeListening();
+      log("info", "Resumed: cooldown expired");
+    } else {
+      statusBarItem.text = `$(clock) Wake: ${countdownRemaining}s`;
+    }
+  }, 1000);
+
+  log("info", `Cooldown: ${seconds}s`);
 }
 
 function resumeListening() {
@@ -334,10 +351,11 @@ function resumeListening() {
 }
 
 function clearResumeTimer() {
-  if (resumeTimer) {
-    clearTimeout(resumeTimer);
-    resumeTimer = null;
+  if (countdownTimer) {
+    clearInterval(countdownTimer);
+    countdownTimer = null;
   }
+  countdownRemaining = 0;
 }
 
 // ── Status bar ──────────────────────────────────────────────

--- a/src/sherpaEngine.ts
+++ b/src/sherpaEngine.ts
@@ -1,0 +1,419 @@
+import { EventEmitter } from "events";
+import { spawn, ChildProcess, execSync } from "child_process";
+import { existsSync, mkdirSync, createWriteStream, writeFileSync, readFileSync, unlinkSync } from "fs";
+import * as path from "path";
+import * as https from "https";
+import { pipeline } from "stream/promises";
+import * as vscode from "vscode";
+import { ISpeechEngine, WakePhrase } from "./speechEngineInterface";
+
+/**
+ * Cross-platform speech recognition engine using sherpa-onnx keyword spotting.
+ *
+ * Spawns audio-engine.js as a child process under system Node.js (not Electron),
+ * so that native addons (micstream) load against the correct Node.js ABI.
+ * sherpa-onnx (WASM) and sentencepiece-js (WASM) are also loaded in the child.
+ *
+ * Supports Windows, macOS, and Linux.
+ */
+export class SherpaEngine extends EventEmitter implements ISpeechEngine {
+  private process: ChildProcess | null = null;
+  private currentPhrases: WakePhrase[] = [];
+  private _isListening = false;
+  private _isPaused = false;
+  private _killedIntentionally = false;
+  private currentThreshold = 0.3;
+  private currentDebugMode = false;
+  private retryCount = 0;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly MAX_RETRIES = 3;
+  private static readonly RETRY_DELAYS = [2000, 5000, 10000];
+
+  constructor(
+    private readonly context: vscode.ExtensionContext,
+    private readonly nodePathOverride: string = ""
+  ) {
+    super();
+  }
+
+  get isListening(): boolean {
+    return this._isListening;
+  }
+
+  get isPaused(): boolean {
+    return this._isPaused;
+  }
+
+  async start(phrases: WakePhrase[], confidenceThreshold = 0.3, debugMode = false): Promise<void> {
+    if (this._isListening) {
+      return;
+    }
+
+    this.killProcess();
+
+    this._killedIntentionally = false;
+    this.currentPhrases = phrases;
+    const safeThreshold = Math.max(0.1, Math.min(0.9, Number(confidenceThreshold) || 0.3));
+    this.currentThreshold = safeThreshold;
+    this.currentDebugMode = debugMode;
+
+    // Ensure model is downloaded
+    let modelDir: string;
+    try {
+      modelDir = await ensureModel(this.context, debugMode ? (msg: string) => this.emit("debug", msg) : undefined);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.emit("error", new Error("Model unavailable: " + message));
+      return;
+    }
+
+    const nodePath = findSystemNode(this.nodePathOverride);
+    const engineScript = path.join(path.dirname(__dirname), "engine", "audio-engine.js");
+    this.emit("debug", `Spawning: ${nodePath} ${engineScript}`);
+
+    this.process = spawn(nodePath, [engineScript], {
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    // Send config as JSON line then leave stdin open (child reads more commands)
+    const config = {
+      phrases: phrases.map((p) => ({
+        phrase: p.phrase,
+        label: p.label,
+      })),
+      threshold: safeThreshold,
+      modelDir,
+      debugMode,
+    };
+    this.process.stdin?.write(JSON.stringify(config) + "\n");
+
+    let stdoutBuffer = "";
+
+    this.process.stdout?.on("data", (data: Buffer) => {
+      stdoutBuffer += data.toString();
+      const lines = stdoutBuffer.split("\n");
+      stdoutBuffer = lines.pop() || "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+
+        if (trimmed === "READY") {
+          this._isListening = true;
+          this._isPaused = false;
+          this.retryCount = 0;
+          this.emit("started");
+        } else if (trimmed.startsWith("DEBUG:")) {
+          this.emit("debug", trimmed.substring(6));
+        } else if (trimmed.startsWith("ERROR:")) {
+          this.emit("error", new Error(trimmed.substring(6)));
+        } else if (trimmed.startsWith("DETECTED:")) {
+          const payload = trimmed.substring(9);
+          const sepIndex = payload.lastIndexOf("|");
+          const detected = (sepIndex >= 0 ? payload.substring(0, sepIndex) : payload).toLowerCase().trim();
+          const confidence = sepIndex >= 0 ? parseFloat(payload.substring(sepIndex + 1)) : 1.0;
+          const match = phrases.find((p) =>
+            normalizePhrases(p.phrase).includes(detected)
+          );
+          if (match) {
+            this.emit("detected", match, isNaN(confidence) ? 1.0 : confidence);
+          }
+        }
+      }
+    });
+
+    this.process.stderr?.on("data", (data: Buffer) => {
+      this.emit("debug", "stderr: " + data.toString().trim());
+    });
+
+    this.process.on("error", (err) => {
+      this._isListening = false;
+      this._isPaused = false;
+      this.process = null;
+
+      if (err.message.includes("ENOENT") || err.message.includes("not found")) {
+        this.emit(
+          "error",
+          new Error(
+            "Could not find Node.js. Set `wakeWord.nodePath` in Settings to " +
+              "the full path to your node executable."
+          )
+        );
+      } else {
+        this.emit("error", new Error("Failed to start audio engine: " + err.message));
+      }
+    });
+
+    this.process.on("exit", (code) => {
+      const wasListening = this._isListening;
+      this._isListening = false;
+      this.process = null;
+
+      this.emit("debug", `Process exited: code=${code}, killed=${this._killedIntentionally}`);
+
+      if (this._killedIntentionally) {
+        if (wasListening && !this._isPaused) {
+          this.emit("stopped");
+        }
+        return;
+      }
+
+      if (code !== 0) {
+        const msg = `exit code ${code}`;
+        if (this.retryCount < SherpaEngine.MAX_RETRIES) {
+          const delay = SherpaEngine.RETRY_DELAYS[this.retryCount];
+          this.retryCount++;
+          this.emit(
+            "warning",
+            `Audio engine crashed: ${msg}. Retrying in ${delay / 1000}s ` +
+              `(attempt ${this.retryCount}/${SherpaEngine.MAX_RETRIES})...`
+          );
+          this.retryTimer = setTimeout(() => {
+            this.retryTimer = null;
+            this.start(this.currentPhrases, this.currentThreshold, this.currentDebugMode);
+          }, delay);
+          return;
+        }
+
+        this.emit("error", new Error(`${msg} (failed after ${SherpaEngine.MAX_RETRIES} retries)`));
+        return;
+      }
+
+      if (wasListening && !this._isPaused) {
+        this.emit("stopped");
+      }
+    });
+  }
+
+  stop(): void {
+    if (!this._isListening && !this._isPaused) {
+      return;
+    }
+
+    this._isPaused = false;
+    this.retryCount = 0;
+    this.clearRetryTimer();
+    this.killProcess();
+    this._isListening = false;
+    this.emit("stopped");
+  }
+
+  pause(): void {
+    if (!this._isListening) {
+      return;
+    }
+
+    this._isPaused = true;
+    this.clearRetryTimer();
+    this.killProcess();
+    this._isListening = false;
+    this.emit("paused");
+  }
+
+  resume(): void {
+    if (!this._isPaused || this.currentPhrases.length === 0) {
+      return;
+    }
+
+    this.retryCount = 0;
+    this.start(this.currentPhrases, this.currentThreshold, this.currentDebugMode);
+  }
+
+  dispose(): void {
+    this.clearRetryTimer();
+    this.stop();
+    this.removeAllListeners();
+  }
+
+  private clearRetryTimer(): void {
+    if (this.retryTimer) {
+      clearTimeout(this.retryTimer);
+      this.retryTimer = null;
+    }
+  }
+
+  private killProcess(): void {
+    if (this.process) {
+      this._killedIntentionally = true;
+      this.process.stdout?.removeAllListeners();
+      this.process.stderr?.removeAllListeners();
+      // Send stop command before killing so the mic is released cleanly
+      try {
+        this.process.stdin?.write("stop\n");
+        this.process.stdin?.end();
+      } catch {
+        // Process may have already exited
+      }
+      this.process.removeAllListeners();
+      try {
+        this.process.kill();
+      } catch {
+        // Process may have already exited
+      }
+      this.process = null;
+    }
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────
+
+function normalizePhrases(phrase: string | string[]): string[] {
+  const arr = Array.isArray(phrase) ? phrase : [phrase];
+  return arr.map((p) => p.toLowerCase().trim()).filter((p) => p.length > 0);
+}
+
+/**
+ * Locate the system Node.js executable.
+ *
+ * Resolution order:
+ *   1. wakeWord.nodePath user setting (highest priority)
+ *   2. `where node` / `which node` shell command
+ *   3. Well-known install paths per platform
+ *   4. Bare 'node' as last resort
+ */
+export function findSystemNode(override?: string): string {
+  if (override) return override;
+
+  try {
+    const cmd = process.platform === "win32" ? "where node" : "which node";
+    const result = execSync(cmd, { encoding: "utf8" }).trim().split("\n")[0].trim();
+    if (result) return result;
+  } catch {
+    // fall through
+  }
+
+  const wellKnown =
+    process.platform === "win32"
+      ? ["C:\\Program Files\\nodejs\\node.exe"]
+      : process.platform === "darwin"
+      ? ["/opt/homebrew/bin/node", "/usr/local/bin/node"]
+      : ["/usr/bin/node", "/usr/local/bin/node"];
+
+  for (const p of wellKnown) {
+    if (existsSync(p)) return p;
+  }
+
+  return "node";
+}
+
+// ── Model management ─────────────────────────────────────────
+
+const MODEL_VERSION = "1";
+const MODEL_NAME = "sherpa-onnx-kws-zipformer-gigaspeech-3.3M-2024-01-01";
+const MODEL_URL =
+  "https://github.com/k2-fsa/sherpa-onnx/releases/download/kws-models/" +
+  MODEL_NAME + ".tar.bz2";
+
+const MODEL_FILES = [
+  "encoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx",
+  "decoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx",
+  "joiner-epoch-12-avg-2-chunk-16-left-64.int8.onnx",
+  "tokens.txt",
+  "bpe.model",
+];
+
+/**
+ * Ensure the KWS model is downloaded to globalStorage.
+ * Returns the path to the model directory.
+ */
+export async function ensureModel(
+  context: vscode.ExtensionContext,
+  debugLog?: (msg: string) => void
+): Promise<string> {
+  const storageUri = context.globalStorageUri;
+  const modelDir = path.join(storageUri.fsPath, "sherpa-onnx", MODEL_NAME);
+  const versionFile = path.join(storageUri.fsPath, "sherpa-onnx", "version.txt");
+
+  // Check if model is already present and version matches
+  const allFilesPresent = MODEL_FILES.every((f) => existsSync(path.join(modelDir, f)));
+  let versionMatch = false;
+  if (allFilesPresent && existsSync(versionFile)) {
+    try {
+      versionMatch = readFileSync(versionFile, "utf8").trim() === MODEL_VERSION;
+    } catch {
+      versionMatch = false;
+    }
+  }
+
+  if (allFilesPresent && versionMatch) {
+    debugLog?.("Model already present at " + modelDir);
+    return modelDir;
+  }
+
+  // Model missing or outdated — download
+  return downloadModel(context, modelDir, versionFile, debugLog);
+}
+
+async function downloadModel(
+  context: vscode.ExtensionContext,
+  modelDir: string,
+  versionFile: string,
+  debugLog?: (msg: string) => void
+): Promise<string> {
+  return vscode.window.withProgress(
+    {
+      location: vscode.ProgressLocation.Notification,
+      title: "Wake Word: Downloading speech model (~17MB)...",
+      cancellable: false,
+    },
+    async (progress) => {
+      const storageDir = path.dirname(modelDir);
+      mkdirSync(storageDir, { recursive: true });
+
+      debugLog?.("Downloading model from " + MODEL_URL);
+      progress.report({ message: "Connecting..." });
+
+      const tarballPath = path.join(storageDir, MODEL_NAME + ".tar.bz2");
+
+      // Download tarball (following redirects — GitHub releases return 302 → CDN)
+      await new Promise<void>((resolve, reject) => {
+        const file = createWriteStream(tarballPath);
+
+        function get(url: string): void {
+          https.get(url, (res) => {
+            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+              get(res.headers.location);
+              return;
+            }
+            if (res.statusCode !== 200) {
+              reject(new Error(`HTTP ${res.statusCode} downloading model`));
+              return;
+            }
+            const total = parseInt(res.headers["content-length"] || "0", 10);
+            let received = 0;
+            res.on("data", (chunk: Buffer) => {
+              received += chunk.length;
+              if (total > 0) {
+                progress.report({
+                  message: `${Math.round((received / total) * 100)}%`,
+                  increment: (chunk.length / total) * 100,
+                });
+              }
+            });
+            pipeline(res, file).then(resolve).catch(reject);
+          }).on("error", reject);
+        }
+
+        get(MODEL_URL);
+      });
+
+      progress.report({ message: "Extracting..." });
+      debugLog?.("Extracting " + tarballPath);
+
+      // Use system tar (available on macOS and Linux where SherpaEngine is used)
+      execSync(`tar -xjf "${tarballPath}" -C "${storageDir}"`);
+
+      // Write version file
+      writeFileSync(versionFile, MODEL_VERSION, "utf8");
+
+      // Clean up tarball
+      try {
+        unlinkSync(tarballPath);
+      } catch {
+        // non-fatal
+      }
+
+      debugLog?.("Model ready at " + modelDir);
+      return modelDir;
+    }
+  );
+}

--- a/src/speechEngineInterface.ts
+++ b/src/speechEngineInterface.ts
@@ -6,7 +6,7 @@ export interface WakePhrase {
 }
 
 export interface ISpeechEngine {
-  start(phrases: WakePhrase[], threshold: number, debugMode: boolean): void;
+  start(phrases: WakePhrase[], threshold: number, debugMode: boolean): void | Promise<void>;
   stop(): void;
   pause(): void;
   resume(): void;

--- a/src/speechEngineInterface.ts
+++ b/src/speechEngineInterface.ts
@@ -1,0 +1,21 @@
+export interface WakePhrase {
+  label: string;
+  phrase: string | string[];
+  command: string;
+  cooldownSeconds?: number;
+}
+
+export interface ISpeechEngine {
+  start(phrases: WakePhrase[], threshold: number, debugMode: boolean): void;
+  stop(): void;
+  pause(): void;
+  resume(): void;
+  dispose(): void;
+  on(event: "detected", cb: (phrase: WakePhrase, confidence: number) => void): this;
+  on(event: "started" | "stopped" | "paused", cb: () => void): this;
+  on(event: "error", cb: (err: Error) => void): this;
+  on(event: "warning", cb: (msg: string) => void): this;
+  on(event: "debug", cb: (info: string) => void): this;
+  readonly isListening: boolean;
+  readonly isPaused: boolean;
+}

--- a/src/windowsSpeechEngine.ts
+++ b/src/windowsSpeechEngine.ts
@@ -1,25 +1,18 @@
 import { EventEmitter } from "events";
 import { spawn, ChildProcess } from "child_process";
-import * as os from "os";
-
-export interface WakePhrase {
-  label: string;
-  phrase: string | string[];
-  command: string;
-  cooldownSeconds?: number;
-}
+import { ISpeechEngine, WakePhrase } from "./speechEngineInterface";
 
 /**
- * Speech recognition engine for wake word detection.
+ * Speech recognition engine for Windows wake word detection.
  *
- * On Windows, uses the built-in System.Speech.Recognition engine
- * via a PowerShell child process. No API keys, no model downloads,
- * no system dependencies beyond what ships with Windows.
+ * Uses the built-in System.Speech.Recognition engine via a PowerShell
+ * child process. No API keys, no model downloads, no system dependencies
+ * beyond what ships with Windows.
  *
  * The engine uses a constrained grammar built from the configured
  * wake phrases for accurate matching.
  */
-export class SpeechEngine extends EventEmitter {
+export class WindowsSpeechEngine extends EventEmitter implements ISpeechEngine {
   private process: ChildProcess | null = null;
   private currentPhrases: WakePhrase[] = [];
   private _isListening = false;
@@ -48,23 +41,12 @@ export class SpeechEngine extends EventEmitter {
     // Clean up any orphaned process from a previous session
     this.killProcess();
 
-    if (os.platform() !== "win32") {
-      this.emit(
-        "error",
-        new Error(
-          "Wake Word currently supports Windows only. " +
-            "macOS and Linux support is planned for a future release."
-        )
-      );
-      return;
-    }
-
     this._killedIntentionally = false;
     this.currentPhrases = phrases;
     const safeThreshold = Math.max(0.1, Math.min(0.9, Number(confidenceThreshold) || 0.3));
     this.currentThreshold = safeThreshold;
     this.currentDebugMode = debugMode;
-    const phraseStrings = phrases.flatMap((p) => SpeechEngine.normalizePhrases(p.phrase));
+    const phraseStrings = phrases.flatMap((p) => WindowsSpeechEngine.normalizePhrases(p.phrase));
     const script = this.buildScript(phraseStrings, safeThreshold, debugMode);
     const encoded = Buffer.from(script, "utf16le").toString("base64");
 
@@ -102,7 +84,7 @@ export class SpeechEngine extends EventEmitter {
           const detected = (sepIndex >= 0 ? payload.substring(0, sepIndex) : payload).toLowerCase().trim();
           const confidence = sepIndex >= 0 ? parseFloat(payload.substring(sepIndex + 1)) : 0;
           const match = phrases.find((p) =>
-            SpeechEngine.normalizePhrases(p.phrase).includes(detected)
+            WindowsSpeechEngine.normalizePhrases(p.phrase).includes(detected)
           );
           if (match) {
             this.emit("detected", match, isNaN(confidence) ? 0 : confidence);
@@ -147,10 +129,10 @@ export class SpeechEngine extends EventEmitter {
         const stderrMsg = stderrBuffer.trim() ? this.parseStderr(stderrBuffer) : "";
         const msg = stderrMsg || `exit code ${code}`;
 
-        if (this.retryCount < SpeechEngine.MAX_RETRIES) {
-          const delay = SpeechEngine.RETRY_DELAYS[this.retryCount];
+        if (this.retryCount < WindowsSpeechEngine.MAX_RETRIES) {
+          const delay = WindowsSpeechEngine.RETRY_DELAYS[this.retryCount];
           this.retryCount++;
-          this.emit("warning", `Speech engine crashed: ${msg}. Retrying in ${delay / 1000}s (attempt ${this.retryCount}/${SpeechEngine.MAX_RETRIES})...`);
+          this.emit("warning", `Speech engine crashed: ${msg}. Retrying in ${delay / 1000}s (attempt ${this.retryCount}/${WindowsSpeechEngine.MAX_RETRIES})...`);
           this.retryTimer = setTimeout(() => {
             this.retryTimer = null;
             this.start(this.currentPhrases, this.currentThreshold, this.currentDebugMode);
@@ -158,7 +140,7 @@ export class SpeechEngine extends EventEmitter {
           return;
         }
 
-        this.emit("error", new Error(`${msg} (failed after ${SpeechEngine.MAX_RETRIES} retries)`));
+        this.emit("error", new Error(`${msg} (failed after ${WindowsSpeechEngine.MAX_RETRIES} retries)`));
         return;
       }
 


### PR DESCRIPTION
### Added

- **Cross-platform speech engine** (SherpaEngine) using sherpa-onnx keyword spotting. Supports Windows, macOS, and Linux. Runs as a child process under system Node.js so native audio addons load against the correct Node.js ABI, with no Electron conflicts.
- **Cross-platform microphone capture** via `@analyticsinmotion/micstream` (PortAudio). This resolves a fundamental blocker: VS Code's Electron runtime cannot load native audio addons, so there was previously no way to capture microphone audio on macOS or Linux. Running micstream under system Node.js in the engine child process bypasses this entirely.
- `wakeWord.engine` setting to select the speech engine: `auto` (platform default), `windows` (Windows System.Speech), or `sherpa` (sherpa-onnx, cross-platform). Defaults to `auto`.
- `wakeWord.nodePath` setting to override the Node.js executable path used by SherpaEngine. Useful when Node.js is installed via nvm, fnm, or a non-standard location not on VS Code's PATH.
- Engine indicator in the status bar showing the active engine (`Windows` or `Sherpa`) while listening. Click the indicator to open engine settings.
- Changing `wakeWord.engine` or `wakeWord.nodePath` in Settings now takes effect immediately; the engine restarts without reloading the window.
- Status bar countdown during cooldown: after a wake phrase fires, the status bar shows a live second-by-second countdown (`Wake: 30s → Wake: 29s → ...`) instead of a static "Wake: Active" message. Gives clear feedback on how long until listening resumes.

### Changed

- Countdown uses a clock icon (`$(clock)`) rather than the spinning sync icon. The spinning icon reset its CSS animation every second when the status bar text was updated, causing a visible jerk. The clock icon is static and appropriate for a timed countdown.
- Documentation updated to be editor-neutral: "VS Code" replaced with "your editor" or "the editor" in settings descriptions, README subheading, and How It Works section. The extension works in Cursor, Windsurf, and other VS Code forks. The docs now reflect that. Technical content (platform requirements, command IDs, architecture) is unchanged.
- Both engines now implement a shared `ISpeechEngine` interface, enabling clean engine switching and shared event handling.

### Fixed

- Switching the speech engine during an active cooldown no longer cancels the countdown or breaks subsequent detection. The countdown continues normally; the new engine starts when it expires.
- Model download now follows HTTP redirects. GitHub release URLs return `302 → CDN`. Downloads previously failed silently on first install.