### PR TITLE
v0.5.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,21 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: windows-latest
+            target: win32-x64
+            lint: true
+          - os: macos-latest
+            target: darwin-arm64
+            lint: false
+          - os: ubuntu-latest
+            target: linux-x64
+            lint: false
+
+    runs-on: ${{ matrix.os }}
+
     steps:
       - uses: actions/checkout@v4
 
@@ -16,28 +30,33 @@ jobs:
 
       - run: npm ci
 
-      - run: npm run lint
+      - name: Install engine dependencies
+        run: cd engine && npm install
 
-      - run: npm run compile
+      - name: Lint and compile
+        if: matrix.lint
+        run: |
+          npm run lint
+          npm run compile
 
-      # Build .vsix package
+      # Build platform-specific .vsix package
       - name: Package extension
-        run: npx vsce package -o wake-word-${{ github.event.release.tag_name }}.vsix
+        run: npx vsce package --target ${{ matrix.target }} -o wake-word-${{ matrix.target }}-${{ github.event.release.tag_name }}.vsix
 
       # Attach .vsix to the GitHub release
       - name: Upload .vsix to release
         uses: softprops/action-gh-release@v1
         with:
-          files: wake-word-${{ github.event.release.tag_name }}.vsix
+          files: wake-word-${{ matrix.target }}-${{ github.event.release.tag_name }}.vsix
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Publish to VS Code Marketplace
       - name: Publish to VS Code Marketplace
-        run: npx vsce publish
+        run: npx vsce publish --target ${{ matrix.target }}
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
 
       # Publish to Open VSX Registry
       - name: Publish to Open VSX
-        run: npx ovsx publish -p ${{ secrets.OVSX_PAT }}
+        run: npx ovsx publish wake-word-${{ matrix.target }}-${{ github.event.release.tag_name }}.vsix -p ${{ secrets.OVSX_PAT }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ wake-word/
   src/
     extension.ts              # VS Code extension entry point, commands, status bar, consent flow
     speechEngineInterface.ts  # ISpeechEngine interface (implemented by both engines)
-    windowsSpeechEngine.ts    # WindowsSpeechEngine — spawns PowerShell, Windows System.Speech
-    sherpaEngine.ts           # SherpaEngine — spawns audio-engine.js under system Node.js
+    windowsSpeechEngine.ts    # WindowsSpeechEngine: PowerShell child process using Windows System.Speech
+    sherpaEngine.ts           # SherpaEngine: audio-engine.js child process under system Node.js
   engine/
     audio-engine.js           # Child process: micstream mic capture + sherpa-onnx keyword spotting
     package.json              # Engine dependencies (micstream, sherpa-onnx, sentencepiece-js)
@@ -33,7 +33,7 @@ wake-word/
     release.yml        # CI: build .vsix, publish to Marketplace and Open VSX
 ```
 
-`extension.ts` owns all VS Code API interactions. Both engines implement `ISpeechEngine` — `windowsSpeechEngine.ts` for Windows, `sherpaEngine.ts` for cross-platform. `audio-engine.js` runs under system Node.js (not Electron) so native audio addons load correctly. Keep this separation clean.
+`extension.ts` owns all VS Code API interactions. Both engines implement `ISpeechEngine`: `windowsSpeechEngine.ts` (Windows) and `sherpaEngine.ts` (cross-platform). `audio-engine.js` runs under system Node.js (not Electron) so native audio addons load correctly. Keep this separation clean.
 
 ## Architecture
 
@@ -54,6 +54,7 @@ On wake word detection, the engine process is killed to release the microphone (
 - All speech processing must remain local. No network calls for audio or recognition.
 - Use single-quoted strings in generated PowerShell to prevent injection. Never use double-quoted strings for user-provided phrases.
 - Keep the extension under the `analytics-in-motion` publisher namespace.
+- Avoid em dashes. Rewrite sentences to use a colon, semicolon, or separate sentence instead.
 
 ## Changelog
 
@@ -84,8 +85,8 @@ Manual testing checklist:
 6. Status bar returns to "Wake: Listening" after cooldown; target command fired correctly
 7. Toggle, enable, disable, and reset consent commands all work
 8. Output panel shows "Wake Word" channel with timestamped logs
-9. Change `wakeWord.engine` in Settings while listening — engine restarts immediately, engine indicator updates
-10. Change `wakeWord.engine` during cooldown — countdown continues, new engine starts when it expires
+9. Change `wakeWord.engine` in Settings while listening. Confirm engine restarts immediately and engine indicator updates.
+10. Change `wakeWord.engine` during cooldown. Confirm countdown continues and the new engine starts when it expires.
 
 ## Boundaries
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,8 @@ Manual testing checklist:
 
 **NEVER** use PowerShell double-quoted strings for user-provided content (injection risk).
 
+**NEVER** add `darwin-x64` as a CI build target. Intel Mac (pre-2020) is excluded: the `macos-13` GitHub Actions runner has uncertain long-term availability, and `@analyticsinmotion/micstream` darwin-x64 pre-built binaries are unconfirmed. Revisit only if a darwin-x64 user files an issue with confirmed binary support.
+
 **NEVER** modify the ATTRIBUTION.md protocol frontmatter without explicit instruction.
 
 ## Attribution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.0] - 2026-03-10
+
+### Fixed
+
+- Native engine dependencies (`sherpa-onnx`, `micstream`, `sentencepiece-js`) are now correctly bundled in the published `.vsix`. The v0.4.0 CI build omitted `engine/node_modules` because it was gitignored and never installed in CI. SherpaEngine failed with MODULE_NOT_FOUND on all platforms. Fixed by adding `cd engine && npm install` to each CI job before packaging.
+- Duplicate wake phrase detections within 3 seconds are now suppressed. A buffered `DETECTED` message could arrive on stdout after the engine process was killed, causing a second command to fire.
+
+### Changed
+
+- Release CI now produces platform-specific `.vsix` files (`win32-x64`, `darwin-arm64`, `linux-x64`), each containing the correct native audio binaries for that platform.
+
+---
+
 ## [0.4.0] - 2026-03-10
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wake-word",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wake-word",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for your editor with customizable wake word. Fully local, zero config.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,8 @@ let speechEngine: ISpeechEngine;
 let isStarting = false;
 let isDevMode = false;
 let isPausedByFocus = false;
+let lastDetectionTime = 0;
+const DETECTION_DEBOUNCE_MS = 3000;
 
 // ── Default routes ──────────────────────────────────────────
 
@@ -155,6 +157,7 @@ export function activate(context: vscode.ExtensionContext) {
         const wasListening = speechEngine.isListening;
         const cooldownActive = countdownTimer !== null;
         isPausedByFocus = false;
+        lastDetectionTime = 0;
         speechEngine.dispose();
         speechEngine = createEngine(context);
         wireEngine(speechEngine);
@@ -281,6 +284,7 @@ function startListening() {
 function stopListening() {
   clearResumeTimer();
   isPausedByFocus = false;
+  lastDetectionTime = 0;
   speechEngine.stop();
   setStatusBar("off");
 }
@@ -305,6 +309,13 @@ function buildRoutes(config: vscode.WorkspaceConfiguration): WakePhrase[] {
 // ── Wake word triggered ─────────────────────────────────────
 
 async function onWakeWordDetected(phrase: WakePhrase, confidence: number) {
+  const now = Date.now();
+  if (now - lastDetectionTime < DETECTION_DEBOUNCE_MS) {
+    log("info", `Debounced duplicate detection: ${phrase.label}`);
+    return;
+  }
+  lastDetectionTime = now;
+
   log("info", `Detected: "${phrase.label}" (confidence: ${confidence.toFixed(2)})`);
 
   const config = vscode.workspace.getConfiguration("wakeWord");
@@ -373,6 +384,7 @@ function scheduleResume(seconds: number) {
 
 function resumeListening() {
   clearResumeTimer();
+  lastDetectionTime = 0;
   if (speechEngine.isPaused) {
     speechEngine.resume();
   } else {


### PR DESCRIPTION
### Fixed

- Native engine dependencies (`sherpa-onnx`, `micstream`, `sentencepiece-js`) are now correctly bundled in the published `.vsix`. The v0.4.0 CI build omitted `engine/node_modules` because it was gitignored and never installed in CI. SherpaEngine failed with MODULE_NOT_FOUND on all platforms. Fixed by adding `cd engine && npm install` to each CI job before packaging.
- Duplicate wake phrase detections within 3 seconds are now suppressed. A buffered `DETECTED` message could arrive on stdout after the engine process was killed, causing a second command to fire.

### Changed

- Release CI now produces platform-specific `.vsix` files (`win32-x64`, `darwin-arm64`, `linux-x64`), each containing the correct native audio binaries for that platform.