### PR TITLE
v0.5.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,8 @@ wake-word/
     windowsSpeechEngine.ts    # WindowsSpeechEngine: PowerShell child process using Windows System.Speech
     sherpaEngine.ts           # SherpaEngine: audio-engine.js child process under system Node.js
   engine/
-    audio-engine.js           # Child process: micstream mic capture + sherpa-onnx keyword spotting
-    package.json              # Engine dependencies (micstream, sherpa-onnx, sentencepiece-js)
+    audio-engine.js           # Child process: decibri mic capture + sherpa-onnx keyword spotting
+    package.json              # Engine dependencies (decibri, sherpa-onnx, sentencepiece-js)
   scripts/
     check-readme.js    # Lint-time check: blocks vsce-restricted SVGs in README.md
   dist/                # Compiled JS output (do not edit)
@@ -41,7 +41,7 @@ The extension selects a speech engine via `createEngine()` and wires it with `wi
 
 **WindowsSpeechEngine** spawns a PowerShell process using `System.Speech.Recognition` with a synchronous `Recognize()` polling loop. No model downloads; the engine ships with Windows.
 
-**SherpaEngine** spawns `engine/audio-engine.js` under system Node.js. The child uses `@analyticsinmotion/micstream` for mic capture and `sherpa-onnx` for keyword spotting. Config is sent as a JSON line to stdin. System Node.js is required because Electron cannot load native addons at the correct ABI.
+**SherpaEngine** spawns `engine/audio-engine.js` under system Node.js. The child uses `decibri` for mic capture and `sherpa-onnx` for keyword spotting. Config is sent as a JSON line to stdin. System Node.js is required because Electron cannot load native addons at the correct ABI.
 
 On wake word detection, the engine process is killed to release the microphone (handoff), then respawned after a cooldown. This ensures only one thing uses the mic at a time.
 
@@ -96,7 +96,7 @@ Manual testing checklist:
 
 **NEVER** use PowerShell double-quoted strings for user-provided content (injection risk).
 
-**NEVER** add `darwin-x64` as a CI build target. Intel Mac (pre-2020) is excluded: the `macos-13` GitHub Actions runner has uncertain long-term availability, and `@analyticsinmotion/micstream` darwin-x64 pre-built binaries are unconfirmed. Revisit only if a darwin-x64 user files an issue with confirmed binary support.
+**NEVER** add `darwin-x64` as a CI build target. Intel Mac (pre-2020) is excluded: the `macos-13` GitHub Actions runner has uncertain long-term availability, and `decibri` darwin-x64 pre-built binaries are unconfirmed. Revisit only if a darwin-x64 user files an issue with confirmed binary support.
 
 **NEVER** modify the ATTRIBUTION.md protocol frontmatter without explicit instruction.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,8 @@ Manual testing checklist:
 
 **NEVER** add `Co-Authored-By` or any AI attribution lines to commit messages.
 
+**NEVER** run `git commit`, `git push`, or publish to any branch. The user always commits and pushes manually.
+
 ## Attribution
 
 This repository participates in the AI Attribution Protocol. See ATTRIBUTION.md for reciprocity guidelines.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,8 @@ Manual testing checklist:
 
 **NEVER** modify the ATTRIBUTION.md protocol frontmatter without explicit instruction.
 
+**NEVER** add `Co-Authored-By` or any AI attribution lines to commit messages.
+
 ## Attribution
 
 This repository participates in the AI Attribution Protocol. See ATTRIBUTION.md for reciprocity guidelines.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.5.1] - 2026-03-30
+
+### Changed
+
+- Migrated audio capture dependency from deprecated `@analyticsinmotion/micstream` to `decibri` (v1.0.0). The package was renamed; the API is identical with no functional changes.
+
+### Security
+
+- Bumped `undici` from 7.22.0 to 7.24.1 — fixes 6 CVEs including 3 high-severity WebSocket and HTTP vulnerabilities (PR #8).
+- Bumped `flatted` from 3.3.4 to 3.4.2 — security patch for devDependency (PR #9).
+- Bumped `picomatch` from 4.0.3 to 4.0.4 — security patch for devDependency (PR #10).
+
+---
+
 ## [0.5.0] - 2026-03-10
 
 ### Fixed
 
-- Native engine dependencies (`sherpa-onnx`, `micstream`, `sentencepiece-js`) are now correctly bundled in the published `.vsix`. The v0.4.0 CI build omitted `engine/node_modules` because it was gitignored and never installed in CI. SherpaEngine failed with MODULE_NOT_FOUND on all platforms. Fixed by adding `cd engine && npm install` to each CI job before packaging.
+- Native engine dependencies (`sherpa-onnx`, `decibri`, `sentencepiece-js`) are now correctly bundled in the published `.vsix`. The v0.4.0 CI build omitted `engine/node_modules` because it was gitignored and never installed in CI. SherpaEngine failed with MODULE_NOT_FOUND on all platforms. Fixed by adding `cd engine && npm install` to each CI job before packaging.
 - Duplicate wake phrase detections within 3 seconds are now suppressed. A buffered `DETECTED` message could arrive on stdout after the engine process was killed, causing a second command to fire.
 
 ### Changed
@@ -26,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Cross-platform speech engine** (SherpaEngine) using sherpa-onnx keyword spotting. Supports Windows, macOS, and Linux. Runs as a child process under system Node.js so native audio addons load against the correct Node.js ABI, with no Electron conflicts.
-- **Cross-platform microphone capture** via `@analyticsinmotion/micstream` (PortAudio). This resolves a fundamental blocker: VS Code's Electron runtime cannot load native audio addons, so there was previously no way to capture microphone audio on macOS or Linux. Running micstream under system Node.js in the engine child process bypasses this entirely.
+- **Cross-platform microphone capture** via `decibri` (PortAudio). This resolves a fundamental blocker: VS Code's Electron runtime cannot load native audio addons, so there was previously no way to capture microphone audio on macOS or Linux. Running decibri under system Node.js in the engine child process bypasses this entirely.
 - `wakeWord.engine` setting to select the speech engine: `auto` (platform default), `windows` (Windows System.Speech), or `sherpa` (sherpa-onnx, cross-platform). Defaults to `auto`.
 - `wakeWord.nodePath` setting to override the Node.js executable path used by SherpaEngine. Useful when Node.js is installed via nvm, fnm, or a non-standard location not on VS Code's PATH.
 - Engine indicator in the status bar showing the active engine (`Windows` or `Sherpa`) while listening. Click the indicator to open engine settings.

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Spawns a PowerShell process using `System.Speech.Recognition.SpeechRecognitionEn
 
 ### Sherpa engine (default on macOS/Linux, optional on Windows)
 
-Spawns `audio-engine.js` under **system Node.js** (not Electron). The child process uses `@analyticsinmotion/micstream` (PortAudio) for mic capture and `sherpa-onnx` for keyword spotting. Running under system Node.js is required because Electron's Node.js runtime cannot load native audio addons. A local speech model (~17MB) is downloaded to VS Code's global storage on first use and cached.
+Spawns `audio-engine.js` under **system Node.js** (not Electron). The child process uses `decibri` (PortAudio) for mic capture and `sherpa-onnx` for keyword spotting. Running under system Node.js is required because Electron's Node.js runtime cannot load native audio addons. A local speech model (~17MB) is downloaded to VS Code's global storage on first use and cached.
 
 ### Shared flow
 

--- a/engine/audio-engine.js
+++ b/engine/audio-engine.js
@@ -71,7 +71,7 @@ async function main(config) {
   // Load sentencepiece for BPE tokenisation
   const { SentencePieceProcessor } = require('sentencepiece-js');
   const sherpa = require('sherpa-onnx');
-  const MicStream = require('@analyticsinmotion/micstream');
+  const Decibri = require('decibri');
 
   // Tokenise each phrase and build a lookup map: DECODED_UPPER → phrase string
   const sp = new SentencePieceProcessor();
@@ -137,7 +137,7 @@ async function main(config) {
   // Open microphone
   if (debugMode) debug('opening microphone...');
   try {
-    mic = new MicStream({ sampleRate: 16000, channels: 1 });
+    mic = new Decibri({ sampleRate: 16000, channels: 1 });
   } catch (err) {
     fatal('Failed to open microphone: ' + err.message);
     return;

--- a/engine/package-lock.json
+++ b/engine/package-lock.json
@@ -8,15 +8,24 @@
       "name": "wake-word-engine",
       "version": "1.0.0",
       "dependencies": {
-        "@analyticsinmotion/micstream": "latest",
-        "sentencepiece-js": "latest",
-        "sherpa-onnx": "latest"
+        "decibri": "^1.0.0",
+        "sentencepiece-js": "1.1.0",
+        "sherpa-onnx": "1.12.28"
       }
     },
-    "node_modules/@analyticsinmotion/micstream": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@analyticsinmotion/micstream/-/micstream-0.4.0.tgz",
-      "integrity": "sha512-l+7xaKYwNAGbIxBR0icQHhPfIlIUs4aum8oNCBLftSa9c5/Zv7SCdxmqGQSm09AFEXHLOq//nD9dT0GWshywOA==",
+    "node_modules/app-root-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
+      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/decibri": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/decibri/-/decibri-1.0.0.tgz",
+      "integrity": "sha512-zQ3PUoNneE1zuVHXnHqw79rmLwaRBN5J1ABL7b0OanoscEVU/XtYQzY5+vtuWcPv1QM31mQU9vqnlky0mh9XMQ==",
       "cpu": [
         "x64",
         "arm64"
@@ -32,16 +41,7 @@
         "node-gyp-build": "^4.6.0"
       },
       "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/app-root-path": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
-      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6.0.0"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/node-gyp-build": {

--- a/engine/package.json
+++ b/engine/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "main": "audio-engine.js",
   "dependencies": {
-    "@analyticsinmotion/micstream": "0.4.0",
+    "decibri": "^1.0.0",
     "sentencepiece-js": "1.1.0",
     "sherpa-onnx": "1.12.28"
   }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for your editor with customizable wake word. Fully local, zero config.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",

--- a/src/sherpaEngine.ts
+++ b/src/sherpaEngine.ts
@@ -11,7 +11,7 @@ import { ISpeechEngine, WakePhrase } from "./speechEngineInterface";
  * Cross-platform speech recognition engine using sherpa-onnx keyword spotting.
  *
  * Spawns audio-engine.js as a child process under system Node.js (not Electron),
- * so that native addons (micstream) load against the correct Node.js ABI.
+ * so that native addons (decibri) load against the correct Node.js ABI.
  * sherpa-onnx (WASM) and sentencepiece-js (WASM) are also loaded in the child.
  *
  * Supports Windows, macOS, and Linux.


### PR DESCRIPTION
### Changed

- Migrated audio capture dependency from deprecated `@analyticsinmotion/micstream` to `decibri` (v1.0.0). The package was renamed; the API is identical with no functional changes.

### Security

- Bumped `undici` from 7.22.0 to 7.24.1 — fixes 6 CVEs including 3 high-severity WebSocket and HTTP vulnerabilities (PR #8).
- Bumped `flatted` from 3.3.4 to 3.4.2 — security patch for devDependency (PR #9).
- Bumped `picomatch` from 4.0.3 to 4.0.4 — security patch for devDependency (PR #10).