### PR TITLE
v0.6.0: decibri 5.7.0, VAD-gated keyword spotting, test suite, security fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "@types/vscode"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
 
   # The engine tree — the only dependency tree that reaches end users.
   - package-ecosystem: npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Compile
         run: npm run compile
 
+      - name: Test
+        run: npm test
+
       # The engine tree is the only dependency tree that ships to users, and a
       # broken engine dependency has shipped a dead release before (v0.5.0).
       - name: Install engine dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .vscode-test/
 .claude/
 prototype/
+coverage/

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -10,6 +10,9 @@ prototype/**
 tsconfig.json
 AGENTS.md
 scripts/**
+tests/**
+coverage/**
+vitest.config.mts
 test-*.js
 **/*.ts
 **/*.map

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,10 +7,13 @@ npm install                # Install dependencies
 npm run compile            # Build TypeScript to dist/
 npm run watch              # Build in watch mode
 npm run lint               # Run ESLint + SVG check on README.md. Do not use --fix.
+npm test                   # Run the unit test suite once (vitest)
+npm run test:watch         # Run the unit tests in watch mode
 npm run package            # Build .vsix package
 ```
 
-Run `npm run lint` and `npm run compile` before committing. Both must pass cleanly.
+Run `npm run lint`, `npm run compile`, and `npm test` before committing. All
+three must pass cleanly.
 
 Press F5 in VS Code to launch the Extension Development Host for manual testing.
 
@@ -26,6 +29,16 @@ wake-word/
   engine/
     audio-engine.js           # Child process: decibri VAD-gated mic capture + sherpa-onnx keyword spotting
     package.json              # Engine dependencies (decibri 5.7.0, sherpa-onnx 1.12.28, sentencepiece-js 1.1.0)
+  engine/lib/          # Pure engine logic, unit tested without a microphone
+    model-path.js      # Forward-slash model paths for the sherpa-onnx WASM VFS
+    vad-gate.js        # Pre-roll ring buffer and VAD gate state machine
+    keywords.js        # BPE piece decoding and the keyword list / lookup map
+    control.js         # stdin line draining, config parsing, threshold clamp
+    mic-errors.js      # decibri error codes to user-facing messages
+  tests/
+    unit/              # TypeScript tests for the extension host code
+    engine/            # JavaScript tests for engine/lib
+    mocks/vscode.ts    # Stub for the `vscode` module, wired up in vitest.config.mts
   scripts/
     check-readme.js    # Lint-time check: blocks vsce-restricted SVGs in README.md
   dist/                # Compiled JS output (do not edit)
@@ -37,6 +50,8 @@ wake-word/
 ```
 
 `extension.ts` owns all VS Code API interactions. Both engines implement `ISpeechEngine`: `windowsSpeechEngine.ts` (Windows) and `sherpaEngine.ts` (cross-platform). `audio-engine.js` runs under system Node.js (not Electron) so native audio addons load correctly. Keep this separation clean.
+
+`wakeWordCore.ts` holds the logic both engines and the extension host share: phrase normalisation, route validation, the stdout protocol parser, the debounce guard, engine selection, and the threshold clamp. It imports nothing from `vscode`, so it is directly unit testable. Put shared pure logic there rather than duplicating it per engine. `engine/lib/` is the same idea for the child process.
 
 ## Architecture
 
@@ -78,7 +93,19 @@ Use semantic versioning bumps. Commit changelog updates as `docs(changelog): upd
 
 ## Testing
 
-No test framework is configured yet. When adding tests, use a framework compatible with the VS Code extension testing API.
+Automated tests run under [vitest](https://vitest.dev) with `npm test`. They
+cover pure logic only: no microphone, no child processes, no network, and no
+VS Code API. `vitest.config.mts` aliases the `vscode` module to
+`tests/mocks/vscode.ts` so src modules that import it can still be loaded, and
+that stub throws if a test actually calls into the API.
+
+- `tests/unit/` is TypeScript and imports from `src/`.
+- `tests/engine/` is JavaScript and imports from `engine/lib/`.
+
+Anything that needs a real microphone, a live child process, or the extension
+host still has to be checked by hand. Add a test for pure logic first; if that
+is not possible, extract the logic into `wakeWordCore.ts` or `engine/lib/` and
+then test it.
 
 Manual testing checklist:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Automated unit test suite (vitest, `npm test`) covering phrase
+  normalisation, route validation, the engine stdout protocol parser, the
+  detection debounce guard, engine selection, the confidence threshold
+  clamp, PowerShell CLIXML error extraction, Node.js executable
+  resolution, model download redirect handling, the sherpa-onnx model
+  path normalisation, the VAD pre-roll ring buffer, stdin config
+  parsing, and BPE keyword tokenisation. The suite needs no microphone,
+  no child process, no network, and no VS Code API, and runs on all
+  three platforms in CI.
+
 ### Changed
+
+- Extracted the logic shared by the extension host and both engines into
+  `src/wakeWordCore.ts`, and the pure logic of the audio engine child
+  process into `engine/lib/`. Phrase normalisation and stdout protocol
+  parsing were previously duplicated per engine and drifting; both now
+  have one implementation.
 
 - Upgraded `decibri` from 1.0.0 to 5.7.0 with VAD-gated keyword spotting.
   Audio is now only fed to the keyword spotter while speech is present,
@@ -35,6 +53,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The audio engine child process now handles every complete line in a
+  stdin chunk instead of only the first. Node delivers stdin in chunks,
+  not lines, so a `stop` command arriving behind any other line was
+  silently dropped and the child kept running with the microphone open.
+- Phrase normalisation and route validation no longer throw on a
+  non-string phrase. `wakeWord.routes` is user-edited JSON and VS Code
+  does not enforce the contributed schema, so a number or `null` in a
+  phrase array raised `p.toLowerCase is not a function` and took the
+  extension down during activation. Bad entries are now discarded.
+- Model paths are now built with a POSIX join after separator rewriting,
+  so the path handed to the sherpa-onnx WASM engines is identical on
+  every platform rather than depending on the host separator.
 - `stop()` now cancels pending retry timers in both engines. Previously,
   disabling listening during crash backoff left the retry timer running
   and it reopened the microphone after the user explicitly disabled it.

--- a/engine/audio-engine.js
+++ b/engine/audio-engine.js
@@ -49,6 +49,14 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 // Prepend engine/node_modules to search path
 require.main.paths.unshift(path.join(engineDir, 'node_modules'));
 
+// Pure logic lives in ./lib so it can be unit tested without a microphone.
+// These are relative requires and so bypass the resolver hook above.
+const { modelPath } = require('./lib/model-path');
+const { VadGate } = require('./lib/vad-gate');
+const { buildKeywordSpec } = require('./lib/keywords');
+const { drainLines, parseControlLine, clampKeywordThreshold } = require('./lib/control');
+const { micErrorMessage } = require('./lib/mic-errors');
+
 let mic = null;
 let kws = null;
 let kwsStream = null;
@@ -60,21 +68,6 @@ function out(msg) {
 
 function debug(msg) {
   out('DEBUG:' + msg);
-}
-
-/**
- * Build a path into the model directory that the WASM engines can open.
- *
- * sherpa-onnx is an Emscripten build. Its config validator resolves any path
- * that does not start with '/' against the WASM working directory, so a
- * Windows absolute path like C:\Users\... is never found: createKws() logs
- * "does not exist" / "Errors in config!", still returns a handle, and the
- * unusable spotter then dies with "null function or function signature
- * mismatch" on first use. Forward slashes resolve on every platform, and
- * VS Code's globalStorageUri.fsPath hands us backslashes on Windows.
- */
-function modelPath(modelDir, name) {
-  return path.join(modelDir, name).replace(/\\/g, '/');
 }
 
 function fatal(msg) {
@@ -97,30 +90,22 @@ async function main(config) {
   await sp.load(modelPath(modelDir, 'bpe.model'));
 
   // Build keyword string (one BPE-tokenised phrase per line) and reverse map
-  const phraseMap = {}; // "HEY CLAUDE" → "hey claude"
-  const keywordLines = [];
+  // ("HEY CLAUDE" -> "hey claude").
+  const spec = buildKeywordSpec(phrases, (text) => sp.encodePieces(text));
+  const phraseMap = spec.phraseMap;
 
-  for (const p of phrases) {
-    const raw = Array.isArray(p.phrase) ? p.phrase : [p.phrase];
-    for (const r of raw) {
-      const upper = r.toUpperCase().trim();
-      const tokens = sp.encodePieces(upper);
-      const tokenStr = tokens.join(' ');
-      const decoded = tokens.map(t => t.startsWith('\u2581') ? ' ' + t.slice(1) : t).join('').trim();
-      if (decoded) {
-        phraseMap[decoded] = r.toLowerCase().trim();
-        keywordLines.push(tokenStr);
-        if (debugMode) debug('phrase: ' + r + ' -> tokens: ' + tokenStr + ' -> decoded: ' + decoded);
-      }
+  if (debugMode) {
+    for (const d of spec.details) {
+      debug('phrase: ' + d.phrase + ' -> tokens: ' + d.tokens + ' -> decoded: ' + d.decoded);
     }
   }
 
-  if (keywordLines.length === 0) {
+  if (spec.keywordLines.length === 0) {
     fatal('No valid phrases to detect');
     return;
   }
 
-  const keywords = keywordLines.join('\n');
+  const keywords = spec.keywords;
 
   // Create KWS instance
   if (debugMode) debug('loading sherpa-onnx KWS model...');
@@ -143,7 +128,7 @@ async function main(config) {
       maxActivePaths: 4,
       numTrailingBlanks: 1,
       keywordsScore: 1.0,
-      keywordsThreshold: Math.max(0.1, Math.min(0.9, threshold || 0.25)),
+      keywordsThreshold: clampKeywordThreshold(threshold),
       keywords,
     });
   } catch (err) {
@@ -187,14 +172,13 @@ async function main(config) {
   // VAD gating.
   //
   // decibri emits 'data' for a chunk *before* it scores that chunk, so the
-  // chunk that trips the detector reaches this handler while `speaking` is
-  // still false. Chunks are therefore held in a short pre-roll ring and
-  // flushed into the spotter when 'speech' fires. Without the pre-roll the
-  // onset of the phrase — the syllable that carries the start of the wake
-  // word — never reaches the spotter and detection collapses.
+  // chunk that trips the detector reaches this handler while the gate is still
+  // closed. Chunks are therefore held in a short pre-roll ring and flushed
+  // into the spotter when 'speech' fires. Without the pre-roll the onset of
+  // the phrase, the syllable that carries the start of the wake word, never
+  // reaches the spotter and detection collapses. See lib/vad-gate.js.
   const PREROLL_CHUNKS = 5; // 5 x 100 ms at decibri's default framesPerBuffer
-  const preroll = [];
-  let speaking = false;
+  const gate = new VadGate(PREROLL_CHUNKS);
 
   // Push one Float32 chunk into the spotter and drain whatever it enables.
   function feed(floats) {
@@ -221,17 +205,15 @@ async function main(config) {
 
   mic.on('speech', () => {
     if (stopping) return;
-    speaking = true;
-    if (debugMode) debug('VAD: speech (' + preroll.length + ' pre-roll chunks)');
-    for (const floats of preroll) {
+    const held = gate.prerollLength;
+    if (debugMode) debug('VAD: speech (' + held + ' pre-roll chunks)');
+    for (const floats of gate.speechStarted()) {
       feed(floats);
     }
-    preroll.length = 0;
   });
 
   mic.on('silence', () => {
-    speaking = false;
-    preroll.length = 0;
+    gate.speechEnded();
     if (debugMode) debug('VAD: silence');
     // Decode each speech segment independently. Without the reset the spotter
     // sees the two sides of a gap spliced together and can spot a phrase that
@@ -253,50 +235,15 @@ async function main(config) {
       floats[i] = samples[i] / 32768.0;
     }
 
-    if (!speaking) {
-      // Silence: hold the chunk for the pre-roll and skip the decode entirely.
-      preroll.push(floats);
-      if (preroll.length > PREROLL_CHUNKS) preroll.shift();
-      return;
+    // While silent the gate retains the chunk as pre-roll and returns nothing,
+    // so the decode is skipped entirely.
+    for (const ready of gate.push(floats)) {
+      feed(ready);
     }
-
-    feed(floats);
   });
 
   out('READY');
   if (debugMode) debug('mic open, VAD-gated, listening for: ' + Object.values(phraseMap).join(', '));
-}
-
-/**
- * Map decibri's typed errors to something a user can act on.
- *
- * decibri 5.x raises DecibriError subclasses (DeviceError, OrtError,
- * OrtPathError) each carrying a stable `code`. Anything unrecognised falls
- * back to the raw message under the caller's prefix.
- */
-function micErrorMessage(err, fallbackPrefix) {
-  const code = err && err.code;
-  const message = (err && err.message) || String(err);
-
-  switch (code) {
-    case 'NO_MICROPHONE_FOUND':
-    case 'MICROPHONE_NOT_FOUND':
-      return 'No microphone found. Check your audio device settings.';
-    case 'NOT_AN_INPUT_DEVICE':
-      return 'The selected audio device is not a microphone. Check your audio device settings.';
-    case 'PERMISSION_DENIED':
-      return 'Microphone access denied. Enable microphone access for VS Code in your system privacy settings.';
-    case 'DEVICE_FAILED':
-      return 'The microphone stopped responding: ' + message;
-    case 'ORT_INIT_FAILED':
-    case 'ORT_LOAD_FAILED':
-    case 'ORT_SESSION_BUILD_FAILED':
-    case 'ORT_INFERENCE_FAILED':
-    case 'VAD_MODEL_LOAD_FAILED':
-      return 'Failed to start voice activity detection: ' + message;
-    default:
-      return fallbackPrefix + ': ' + message;
-  }
 }
 
 function shutdown() {
@@ -321,25 +268,29 @@ function shutdown() {
 let stdinBuf = '';
 process.stdin.setEncoding('utf8');
 
+// Node delivers stdin in chunks, not lines, so every complete line in the
+// chunk has to be handled. Taking only the first line dropped the rest: a
+// "stop" that arrived behind another line was never seen and the child kept
+// running with the microphone open.
 process.stdin.on('data', (chunk) => {
   stdinBuf += chunk;
-  const nl = stdinBuf.indexOf('\n');
-  if (nl !== -1) {
-    const line = stdinBuf.substring(0, nl).trim();
-    stdinBuf = stdinBuf.substring(nl + 1);
-    if (line === 'stop') {
+  const drained = drainLines(stdinBuf);
+  stdinBuf = drained.rest;
+
+  for (const line of drained.lines) {
+    const control = parseControlLine(line);
+    if (control.kind === 'stop') {
       shutdown();
       return;
     }
-    if (!line) return;
-    let config;
-    try {
-      config = JSON.parse(line);
-    } catch (e) {
-      fatal('Invalid config JSON: ' + e.message);
+    if (control.kind === 'empty') {
+      continue;
+    }
+    if (control.kind === 'invalid') {
+      fatal(control.message);
       return;
     }
-    main(config).catch((err) => fatal('Startup error: ' + err.message));
+    main(control.config).catch((err) => fatal('Startup error: ' + err.message));
   }
 });
 

--- a/engine/lib/control.js
+++ b/engine/lib/control.js
@@ -1,0 +1,61 @@
+'use strict';
+
+/**
+ * Split a stdin chunk into every complete line it contains, returning the
+ * trailing partial line so the caller can carry it into the next chunk.
+ *
+ * Node delivers stdin in chunks, not lines: a chunk can hold several commands
+ * or none at all. Handling only the first line of a chunk loses the rest, and
+ * a lost "stop" leaves the child running with the microphone open.
+ */
+function drainLines(buffer) {
+  const lines = [];
+  let rest = String(buffer == null ? '' : buffer);
+  let nl = rest.indexOf('\n');
+
+  while (nl !== -1) {
+    lines.push(rest.substring(0, nl));
+    rest = rest.substring(nl + 1);
+    nl = rest.indexOf('\n');
+  }
+
+  return { lines, rest };
+}
+
+/**
+ * Parse one line read from stdin.
+ *
+ * The extension sends a single JSON config line on start and the literal
+ * "stop" when it wants the microphone released.
+ *
+ * @returns {{kind: 'stop'}
+ *   | {kind: 'empty'}
+ *   | {kind: 'config', config: object}
+ *   | {kind: 'invalid', message: string}}
+ */
+function parseControlLine(line) {
+  const trimmed = String(line == null ? '' : line).trim();
+
+  if (trimmed === 'stop') {
+    return { kind: 'stop' };
+  }
+  if (trimmed.length === 0) {
+    return { kind: 'empty' };
+  }
+
+  try {
+    return { kind: 'config', config: JSON.parse(trimmed) };
+  } catch (e) {
+    return { kind: 'invalid', message: 'Invalid config JSON: ' + e.message };
+  }
+}
+
+/**
+ * Clamp the keyword-spotting threshold into the range sherpa-onnx accepts.
+ * Zero, NaN, and missing values fall back to 0.25.
+ */
+function clampKeywordThreshold(threshold) {
+  return Math.max(0.1, Math.min(0.9, threshold || 0.25));
+}
+
+module.exports = { drainLines, parseControlLine, clampKeywordThreshold };

--- a/engine/lib/keywords.js
+++ b/engine/lib/keywords.js
@@ -1,0 +1,74 @@
+'use strict';
+
+/** SentencePiece marks a word boundary with U+2581 LOWER ONE EIGHTH BLOCK. */
+const WORD_BOUNDARY = '▁';
+
+/**
+ * Reverse a SentencePiece piece list back to plain text.
+ *
+ * sherpa-onnx reports a spotted keyword in this decoded form, so the same
+ * function has to produce the lookup key when the keyword list is built:
+ * encode the phrase, decode the pieces, and the round trip is what the spotter
+ * will hand back on a hit.
+ */
+function decodePieces(tokens) {
+  return tokens
+    .map((t) => (t.startsWith(WORD_BOUNDARY) ? ' ' + t.slice(1) : t))
+    .join('')
+    .trim();
+}
+
+/**
+ * Build the sherpa-onnx keyword list and the decoded-to-spoken lookup map.
+ *
+ * @param {Array<{phrase: string|string[], label?: string}>} phrases
+ * @param {(text: string) => string[]} encodePieces SentencePiece encoder
+ * @returns {{
+ *   phraseMap: Object<string, string>,
+ *   keywordLines: string[],
+ *   keywords: string,
+ *   details: Array<{phrase: string, tokens: string, decoded: string}>
+ * }}
+ *
+ * Non-string and blank phrases are skipped rather than thrown on:
+ * `wakeWord.routes` is user-edited JSON and a bad entry must not take the
+ * engine down before the microphone ever opens.
+ */
+function buildKeywordSpec(phrases, encodePieces) {
+  const phraseMap = {};
+  const keywordLines = [];
+  const details = [];
+
+  for (const p of phrases || []) {
+    if (!p) {
+      continue;
+    }
+    const raw = Array.isArray(p.phrase) ? p.phrase : [p.phrase];
+    for (const r of raw) {
+      if (typeof r !== 'string') {
+        continue;
+      }
+      const upper = r.toUpperCase().trim();
+      if (upper.length === 0) {
+        continue;
+      }
+      const tokens = encodePieces(upper);
+      const tokenStr = tokens.join(' ');
+      const decoded = decodePieces(tokens);
+      if (decoded) {
+        phraseMap[decoded] = r.toLowerCase().trim();
+        keywordLines.push(tokenStr);
+        details.push({ phrase: r, tokens: tokenStr, decoded });
+      }
+    }
+  }
+
+  return {
+    phraseMap,
+    keywordLines,
+    keywords: keywordLines.join('\n'),
+    details,
+  };
+}
+
+module.exports = { WORD_BOUNDARY, decodePieces, buildKeywordSpec };

--- a/engine/lib/mic-errors.js
+++ b/engine/lib/mic-errors.js
@@ -1,0 +1,35 @@
+'use strict';
+
+/**
+ * Map decibri's typed errors to something a user can act on.
+ *
+ * decibri 5.x raises DecibriError subclasses (DeviceError, OrtError,
+ * OrtPathError) each carrying a stable `code`. Anything unrecognised falls
+ * back to the raw message under the caller's prefix.
+ */
+function micErrorMessage(err, fallbackPrefix) {
+  const code = err && err.code;
+  const message = (err && err.message) || String(err);
+
+  switch (code) {
+    case 'NO_MICROPHONE_FOUND':
+    case 'MICROPHONE_NOT_FOUND':
+      return 'No microphone found. Check your audio device settings.';
+    case 'NOT_AN_INPUT_DEVICE':
+      return 'The selected audio device is not a microphone. Check your audio device settings.';
+    case 'PERMISSION_DENIED':
+      return 'Microphone access denied. Enable microphone access for VS Code in your system privacy settings.';
+    case 'DEVICE_FAILED':
+      return 'The microphone stopped responding: ' + message;
+    case 'ORT_INIT_FAILED':
+    case 'ORT_LOAD_FAILED':
+    case 'ORT_SESSION_BUILD_FAILED':
+    case 'ORT_INFERENCE_FAILED':
+    case 'VAD_MODEL_LOAD_FAILED':
+      return 'Failed to start voice activity detection: ' + message;
+    default:
+      return fallbackPrefix + ': ' + message;
+  }
+}
+
+module.exports = { micErrorMessage };

--- a/engine/lib/model-path.js
+++ b/engine/lib/model-path.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const path = require('path');
+
+/**
+ * Build a path into the model directory that the WASM engines can open.
+ *
+ * sherpa-onnx is an Emscripten build. Its config validator resolves any path
+ * that does not start with '/' against the WASM working directory, so a
+ * Windows absolute path like C:\Users\... is never found: createKws() logs
+ * "does not exist" / "Errors in config!", still returns a handle, and the
+ * unusable spotter then dies with "null function or function signature
+ * mismatch" on first use. Forward slashes resolve on every platform, and
+ * VS Code's globalStorageUri.fsPath hands us backslashes on Windows.
+ *
+ * Separators are rewritten before joining, and the join is the POSIX one, so
+ * the result is identical whichever platform the engine runs on.
+ */
+function modelPath(modelDir, name) {
+  const posixDir = String(modelDir == null ? '' : modelDir).split('\\').join('/');
+  const posixName = String(name == null ? '' : name).split('\\').join('/');
+  return path.posix.join(posixDir, posixName);
+}
+
+module.exports = { modelPath };

--- a/engine/lib/vad-gate.js
+++ b/engine/lib/vad-gate.js
@@ -1,0 +1,82 @@
+'use strict';
+
+/**
+ * Pre-roll ring buffer and VAD gate state machine.
+ *
+ * decibri emits 'data' for a chunk *before* it scores that chunk, so the chunk
+ * that trips the speech detector arrives while the gate is still closed. Chunks
+ * are therefore held in a short pre-roll ring and flushed into the keyword
+ * spotter when 'speech' fires. Without the pre-roll the onset of the phrase,
+ * the syllable that carries the start of the wake word, never reaches the
+ * spotter and detection collapses.
+ *
+ * The gate holds no audio knowledge: a "chunk" is whatever the caller pushes.
+ */
+class VadGate {
+  /**
+   * @param {number} maxPrerollChunks how many chunks of lead-in to retain
+   */
+  constructor(maxPrerollChunks) {
+    const max = Number(maxPrerollChunks);
+    this.maxPrerollChunks = Number.isFinite(max) && max > 0 ? Math.floor(max) : 0;
+    this._preroll = [];
+    this._speaking = false;
+  }
+
+  /** True while the VAD reports speech. */
+  get speaking() {
+    return this._speaking;
+  }
+
+  /** How many chunks are currently held as lead-in. */
+  get prerollLength() {
+    return this._preroll.length;
+  }
+
+  /**
+   * Accept one captured chunk.
+   *
+   * @returns {Array} chunks to feed the spotter now, in arrival order.
+   *   While speaking that is the chunk itself; while silent it is empty and
+   *   the chunk is retained as pre-roll.
+   */
+  push(chunk) {
+    if (this._speaking) {
+      return [chunk];
+    }
+    if (this.maxPrerollChunks > 0) {
+      this._preroll.push(chunk);
+      if (this._preroll.length > this.maxPrerollChunks) {
+        this._preroll.shift();
+      }
+    }
+    return [];
+  }
+
+  /**
+   * The VAD reported speech.
+   *
+   * @returns {Array} the retained pre-roll, oldest first. The ring is emptied,
+   *   so a second call before any silence returns nothing.
+   */
+  speechStarted() {
+    this._speaking = true;
+    const flushed = this._preroll;
+    this._preroll = [];
+    return flushed;
+  }
+
+  /** The VAD reported silence. Any lead-in captured since is discarded. */
+  speechEnded() {
+    this._speaking = false;
+    this._preroll = [];
+  }
+
+  /** Return to the initial state. */
+  reset() {
+    this._speaking = false;
+    this._preroll = [];
+  }
+}
+
+module.exports = { VadGate };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,14 @@
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",
-        "@types/vscode": "^1.134.0",
+        "@types/vscode": "~1.85.0",
         "@typescript-eslint/eslint-plugin": "^8.67.0",
         "@typescript-eslint/parser": "^8.67.0",
         "@vscode/vsce": "^3.9.2",
         "eslint": "^8.56.0",
         "ovsx": "^1.0.1",
-        "typescript": "^5.3.3"
+        "typescript": "^5.3.3",
+        "vitest": "^4.1.11"
       },
       "engines": {
         "vscode": "^1.85.0"
@@ -769,6 +770,13 @@
         }
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/keyring": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@napi-rs/keyring/-/keyring-1.3.0.tgz",
@@ -1290,6 +1298,278 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.146.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.146.0.tgz",
+      "integrity": "sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm-eabi": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm-eabi/-/binding-android-arm-eabi-1.2.5.tgz",
+      "integrity": "sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.5.tgz",
+      "integrity": "sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.5.tgz",
+      "integrity": "sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.5.tgz",
+      "integrity": "sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.5.tgz",
+      "integrity": "sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.5.tgz",
+      "integrity": "sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.5.tgz",
+      "integrity": "sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.5.tgz",
+      "integrity": "sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.5.tgz",
+      "integrity": "sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.5.tgz",
+      "integrity": "sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.5.tgz",
+      "integrity": "sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.5.tgz",
+      "integrity": "sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.5.tgz",
+      "integrity": "sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.5.tgz",
+      "integrity": "sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@secretlint/config-creator": {
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/@secretlint/config-creator/-/config-creator-10.2.2.tgz",
@@ -1530,6 +1810,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@textlint/ast-node-types": {
       "version": "15.8.0",
       "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.8.0.tgz",
@@ -1593,6 +1880,31 @@
         "@textlint/ast-node-types": "15.8.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.19.35",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
@@ -1618,9 +1930,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.134.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.134.0.tgz",
-      "integrity": "sha512-NDEu0hg4sF7+vvFsADsktqUJ6f80LHSZvVK2Ovo1XiQ0/VHck1O3zst+ZZyVA/uvz6vo6LcuoqU2q48YMqOwWw==",
+      "version": "1.85.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.85.0.tgz",
+      "integrity": "sha512-CF/RBon/GXwdfmnjZj0WTUMZN5H6YITOfBCP4iEZlOtVQXuzw6t7Le7+cR+7JzdMrnlm7Mfp49Oj2TuSXIWo3g==",
       "dev": true,
       "license": "MIT"
     },
@@ -1888,6 +2200,119 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
     },
     "node_modules/@vscode/vsce": {
       "version": "3.9.2",
@@ -2208,6 +2633,16 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -2444,6 +2879,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2594,6 +3039,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -2810,7 +3262,6 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3006,6 +3457,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3214,6 +3672,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3233,6 +3701,16 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3463,6 +3941,21 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -4254,6 +4747,267 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/linkify-it": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
@@ -4371,6 +5125,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/markdown-it": {
@@ -4577,6 +5341,25 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
@@ -4697,6 +5480,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/once": {
@@ -5003,6 +5800,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pend": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
@@ -5018,9 +5822,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5038,6 +5842,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/prebuild-install": {
@@ -5313,6 +6146,40 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.5.tgz",
+      "integrity": "sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.146.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm-eabi": "1.2.5",
+        "@rolldown/binding-android-arm64": "1.2.5",
+        "@rolldown/binding-darwin-arm64": "1.2.5",
+        "@rolldown/binding-darwin-x64": "1.2.5",
+        "@rolldown/binding-freebsd-x64": "1.2.5",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.5",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.5",
+        "@rolldown/binding-linux-arm64-musl": "1.2.5",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.5",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-gnu": "1.2.5",
+        "@rolldown/binding-linux-x64-musl": "1.2.5",
+        "@rolldown/binding-openharmony-arm64": "1.2.5",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.5",
+        "@rolldown/binding-win32-x64-msvc": "1.2.5"
+      }
+    },
     "node_modules/run-applescript": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
@@ -5522,6 +6389,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5625,6 +6499,16 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
@@ -5660,6 +6544,20 @@
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -5866,21 +6764,48 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tmp": {
@@ -6105,6 +7030,174 @@
         "url": "https://bevry.me/fund"
       }
     },
+    "node_modules/vite": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.2.tgz",
+      "integrity": "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.26",
+        "rolldown": "~1.2.4",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0 || ^0.5.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -6143,6 +7236,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -153,6 +153,8 @@
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
     "lint": "eslint src --ext ts && node scripts/check-readme.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "package": "vsce package",
     "publish:vscode": "vsce publish",
     "publish:openvsx": "ovsx publish",
@@ -161,13 +163,14 @@
   },
   "devDependencies": {
     "@types/node": "^20.11.0",
-    "@types/vscode": "^1.134.0",
+    "@types/vscode": "~1.85.0",
+    "@typescript-eslint/eslint-plugin": "^8.67.0",
+    "@typescript-eslint/parser": "^8.67.0",
     "@vscode/vsce": "^3.9.2",
+    "eslint": "^8.56.0",
     "ovsx": "^1.0.1",
     "typescript": "^5.3.3",
-    "eslint": "^8.56.0",
-    "@typescript-eslint/parser": "^8.67.0",
-    "@typescript-eslint/eslint-plugin": "^8.67.0"
+    "vitest": "^4.1.11"
   },
   "dependencies": {}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,13 @@ import * as os from "os";
 import { WakePhrase, ISpeechEngine } from "./speechEngineInterface";
 import { WindowsSpeechEngine } from "./windowsSpeechEngine";
 import { SherpaEngine } from "./sherpaEngine";
+import {
+  DETECTION_DEBOUNCE_MS,
+  clampThreshold,
+  resolveRoutes,
+  selectEngineKind,
+  shouldDebounce,
+} from "./wakeWordCore";
 
 let statusBarItem: vscode.StatusBarItem;
 let engineBarItem: vscode.StatusBarItem;
@@ -14,11 +21,10 @@ let isStarting = false;
 let isDevMode = false;
 let isPausedByFocus = false;
 let lastDetectionTime = 0;
-const DETECTION_DEBOUNCE_MS = 3000;
 
 // ── Default routes ──────────────────────────────────────────
 
-const DEFAULT_ROUTES: WakePhrase[] = [
+export const DEFAULT_ROUTES: WakePhrase[] = [
   {
     label: "Claude",
     phrase: "hey claude",
@@ -43,10 +49,7 @@ function createEngine(context: vscode.ExtensionContext): ISpeechEngine {
   const nodePath = config.get<string>("nodePath", "");
   const engineOverride = config.get<string>("engine", "auto");
 
-  if (engineOverride === "sherpa") {
-    return new SherpaEngine(context, nodePath);
-  }
-  if (engineOverride === "windows" || (engineOverride === "auto" && os.platform() === "win32")) {
+  if (selectEngineKind(engineOverride, os.platform()) === "windows") {
     return new WindowsSpeechEngine();
   }
   return new SherpaEngine(context, nodePath);
@@ -275,7 +278,7 @@ function startListening() {
     return;
   }
 
-  const threshold = config.get<number>("confidenceThreshold", 0.3);
+  const threshold = clampThreshold(config.get<number>("confidenceThreshold", 0.3));
   log("info", `Starting: ${routes.length} routes, threshold=${threshold}, devMode=${isDevMode}`);
   log("info", `OS: ${process.platform} ${process.arch}, VS Code: ${vscode.version}`);
   speechEngine.start(routes, threshold, isDevMode);
@@ -293,24 +296,14 @@ function stopListening() {
 
 function buildRoutes(config: vscode.WorkspaceConfiguration): WakePhrase[] {
   const userRoutes = config.get<WakePhrase[]>("routes", []);
-
-  const validRoutes = userRoutes.filter((r) => {
-    const phrases = Array.isArray(r.phrase) ? r.phrase : [r.phrase];
-    return phrases.some((p) => p?.trim()) && r.label?.trim() && r.command?.trim();
-  });
-
-  if (validRoutes.length > 0) {
-    return validRoutes;
-  }
-
-  return DEFAULT_ROUTES;
+  return resolveRoutes(userRoutes, DEFAULT_ROUTES);
 }
 
 // ── Wake word triggered ─────────────────────────────────────
 
 async function onWakeWordDetected(phrase: WakePhrase, confidence: number) {
   const now = Date.now();
-  if (now - lastDetectionTime < DETECTION_DEBOUNCE_MS) {
+  if (shouldDebounce(now, lastDetectionTime, DETECTION_DEBOUNCE_MS)) {
     log("info", `Debounced duplicate detection: ${phrase.label}`);
     return;
   }

--- a/src/sherpaEngine.ts
+++ b/src/sherpaEngine.ts
@@ -6,6 +6,12 @@ import * as https from "https";
 import { pipeline } from "stream/promises";
 import * as vscode from "vscode";
 import { ISpeechEngine, WakePhrase } from "./speechEngineInterface";
+import {
+  clampThreshold,
+  matchRoute,
+  parseEngineLine,
+  splitLines,
+} from "./wakeWordCore";
 
 /**
  * Cross-platform speech recognition engine using sherpa-onnx keyword spotting.
@@ -53,7 +59,7 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
 
     this._killedIntentionally = false;
     this.currentPhrases = phrases;
-    const safeThreshold = Math.max(0.1, Math.min(0.9, Number(confidenceThreshold) || 0.3));
+    const safeThreshold = clampThreshold(confidenceThreshold);
     this.currentThreshold = safeThreshold;
     this.currentDebugMode = debugMode;
 
@@ -91,31 +97,30 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
 
     this.process.stdout?.on("data", (data: Buffer) => {
       stdoutBuffer += data.toString();
-      const lines = stdoutBuffer.split("\n");
-      stdoutBuffer = lines.pop() || "";
+      const split = splitLines(stdoutBuffer);
+      stdoutBuffer = split.rest;
 
-      for (const line of lines) {
-        const trimmed = line.trim();
+      for (const line of split.lines) {
+        // audio-engine.js always reports 1.0: the keyword spotter has already
+        // applied the threshold, so a missing score means "accepted".
+        const event = parseEngineLine(line, 1.0);
+        if (!event) {
+          continue;
+        }
 
-        if (trimmed === "READY") {
+        if (event.type === "ready") {
           this._isListening = true;
           this._isPaused = false;
           this.retryCount = 0;
           this.emit("started");
-        } else if (trimmed.startsWith("DEBUG:")) {
-          this.emit("debug", trimmed.substring(6));
-        } else if (trimmed.startsWith("ERROR:")) {
-          this.emit("error", new Error(trimmed.substring(6)));
-        } else if (trimmed.startsWith("DETECTED:")) {
-          const payload = trimmed.substring(9);
-          const sepIndex = payload.lastIndexOf("|");
-          const detected = (sepIndex >= 0 ? payload.substring(0, sepIndex) : payload).toLowerCase().trim();
-          const confidence = sepIndex >= 0 ? parseFloat(payload.substring(sepIndex + 1)) : 1.0;
-          const match = phrases.find((p) =>
-            normalizePhrases(p.phrase).includes(detected)
-          );
+        } else if (event.type === "debug") {
+          this.emit("debug", event.message);
+        } else if (event.type === "error") {
+          this.emit("error", new Error(event.message));
+        } else {
+          const match = matchRoute(phrases, event.phrase);
           if (match) {
-            this.emit("detected", match, isNaN(confidence) ? 1.0 : confidence);
+            this.emit("detected", match, event.confidence);
           }
         }
       }
@@ -265,11 +270,6 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
 
 // ── Helpers ─────────────────────────────────────────────────
 
-function normalizePhrases(phrase: string | string[]): string[] {
-  const arr = Array.isArray(phrase) ? phrase : [phrase];
-  return arr.map((p) => p.toLowerCase().trim()).filter((p) => p.length > 0);
-}
-
 /**
  * Locate the system Node.js executable.
  *
@@ -319,6 +319,25 @@ const MODEL_FILES = [
   "tokens.txt",
   "bpe.model",
 ];
+
+/**
+ * True when an HTTP response is a redirect the downloader should follow.
+ *
+ * GitHub release assets answer with a 302 to a CDN host, so the model
+ * download has to follow at least one hop to reach the tarball.
+ */
+export function shouldFollowRedirect(
+  statusCode: number | undefined,
+  location: string | undefined
+): boolean {
+  return (
+    statusCode !== undefined &&
+    statusCode >= 300 &&
+    statusCode < 400 &&
+    typeof location === "string" &&
+    location.length > 0
+  );
+}
 
 /**
  * Ensure the KWS model is downloaded to globalStorage.
@@ -379,8 +398,8 @@ async function downloadModel(
 
         function get(url: string): void {
           https.get(url, (res) => {
-            if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-              get(res.headers.location);
+            if (shouldFollowRedirect(res.statusCode, res.headers.location)) {
+              get(res.headers.location as string);
               return;
             }
             if (res.statusCode !== 200) {

--- a/src/wakeWordCore.ts
+++ b/src/wakeWordCore.ts
@@ -1,0 +1,221 @@
+import { WakePhrase } from "./speechEngineInterface";
+
+/**
+ * Pure logic shared by the extension host and both speech engines.
+ *
+ * Nothing in this module touches the VS Code API, the filesystem, child
+ * processes, or the microphone, so all of it is unit testable. Both engines
+ * speak the same stdout protocol and normalise phrases the same way; keeping
+ * one implementation here means a fix lands in both.
+ */
+
+/** Minimum gap between two accepted detections of any phrase. */
+export const DETECTION_DEBOUNCE_MS = 3000;
+
+/** Bounds enforced on `wakeWord.confidenceThreshold`. */
+export const MIN_THRESHOLD = 0.1;
+export const MAX_THRESHOLD = 0.9;
+export const DEFAULT_THRESHOLD = 0.3;
+
+// -- Phrases ------------------------------------------------------------
+
+/**
+ * Normalise a route's `phrase` field to a list of comparable strings.
+ *
+ * Accepts a single phrase or an array of aliases. Values that are not strings
+ * are discarded rather than thrown on: `wakeWord.routes` is user-edited JSON
+ * and VS Code does not enforce the contributed schema, so a number or null in
+ * the array must not take the extension down on activation.
+ */
+export function normalizePhrases(phrase: unknown): string[] {
+  const arr = Array.isArray(phrase) ? phrase : [phrase];
+  const out: string[] = [];
+  for (const p of arr) {
+    if (typeof p !== "string") {
+      continue;
+    }
+    const normalised = p.toLowerCase().trim();
+    if (normalised.length > 0) {
+      out.push(normalised);
+    }
+  }
+  return out;
+}
+
+/** Find the route whose phrase list contains an already-normalised phrase. */
+export function matchRoute(
+  routes: readonly WakePhrase[],
+  detected: string
+): WakePhrase | undefined {
+  const needle = detected.toLowerCase().trim();
+  if (needle.length === 0) {
+    return undefined;
+  }
+  return routes.find((r) => normalizePhrases(r.phrase).includes(needle));
+}
+
+// -- Routes -------------------------------------------------------------
+
+/** A route is usable only if it has at least one phrase, a label, and a command. */
+export function isValidRoute(route: WakePhrase | undefined | null): boolean {
+  if (!route || typeof route !== "object") {
+    return false;
+  }
+  return (
+    normalizePhrases(route.phrase).length > 0 &&
+    typeof route.label === "string" &&
+    route.label.trim().length > 0 &&
+    typeof route.command === "string" &&
+    route.command.trim().length > 0
+  );
+}
+
+/** Drop routes that cannot be acted on. */
+export function filterValidRoutes(routes: readonly WakePhrase[]): WakePhrase[] {
+  if (!Array.isArray(routes)) {
+    return [];
+  }
+  return routes.filter((r) => isValidRoute(r));
+}
+
+/**
+ * Pick the routing table to start with: the user's valid routes if they have
+ * any, otherwise the built-in defaults.
+ */
+export function resolveRoutes(
+  userRoutes: readonly WakePhrase[],
+  defaults: readonly WakePhrase[]
+): WakePhrase[] {
+  const valid = filterValidRoutes(userRoutes);
+  return valid.length > 0 ? valid : [...defaults];
+}
+
+// -- Threshold ----------------------------------------------------------
+
+/**
+ * Clamp a configured confidence threshold into the supported range.
+ * Non-numeric, NaN, and zero values fall back to `fallback`.
+ */
+export function clampThreshold(
+  value: unknown,
+  fallback: number = DEFAULT_THRESHOLD
+): number {
+  const numeric = Number(value) || fallback;
+  return Math.max(MIN_THRESHOLD, Math.min(MAX_THRESHOLD, numeric));
+}
+
+// -- Debounce -----------------------------------------------------------
+
+/**
+ * True when a detection arrives too soon after the previous accepted one.
+ *
+ * `lastDetectionTime` of 0 means "no detection yet" and never debounces.
+ */
+export function shouldDebounce(
+  now: number,
+  lastDetectionTime: number,
+  windowMs: number = DETECTION_DEBOUNCE_MS
+): boolean {
+  return now - lastDetectionTime < windowMs;
+}
+
+// -- Engine selection ---------------------------------------------------
+
+export type EngineKind = "windows" | "sherpa";
+
+/**
+ * Map the `wakeWord.engine` setting plus the host platform to an engine.
+ *
+ * `auto` picks the built-in Windows engine on Windows and sherpa-onnx
+ * everywhere else. An explicit choice is honoured as given.
+ */
+export function selectEngineKind(override: string, platform: string): EngineKind {
+  if (override === "sherpa") {
+    return "sherpa";
+  }
+  if (override === "windows") {
+    return "windows";
+  }
+  return platform === "win32" ? "windows" : "sherpa";
+}
+
+// -- stdout protocol ----------------------------------------------------
+
+export type EngineEvent =
+  | { type: "ready" }
+  | { type: "detected"; phrase: string; confidence: number }
+  | { type: "error"; message: string }
+  | { type: "debug"; message: string };
+
+/**
+ * Parse one line of an engine's stdout.
+ *
+ * Both engines emit the same four-verb protocol:
+ *   READY
+ *   DETECTED:<phrase>|<confidence>
+ *   ERROR:<message>
+ *   DEBUG:<message>
+ *
+ * Anything else (blank lines, stray output from a child's dependencies)
+ * returns null and is ignored by the caller.
+ *
+ * `defaultConfidence` is used when a DETECTED line carries no `|<confidence>`
+ * suffix or an unparseable one. The sherpa engine's child always reports 1.0,
+ * so it passes 1.0; the Windows engine reports a real score and passes 0 so a
+ * malformed line can never clear a threshold.
+ */
+export function parseEngineLine(
+  line: string,
+  defaultConfidence = 1.0
+): EngineEvent | null {
+  const trimmed = line.trim();
+
+  if (trimmed === "READY") {
+    return { type: "ready" };
+  }
+  if (trimmed.startsWith("DEBUG:")) {
+    return { type: "debug", message: trimmed.substring(6) };
+  }
+  if (trimmed.startsWith("ERROR:")) {
+    return { type: "error", message: trimmed.substring(6) };
+  }
+  if (trimmed.startsWith("DETECTED:")) {
+    const payload = trimmed.substring(9);
+    const sepIndex = payload.lastIndexOf("|");
+    const phrase = (sepIndex >= 0 ? payload.substring(0, sepIndex) : payload)
+      .toLowerCase()
+      .trim();
+    const parsed = sepIndex >= 0 ? parseFloat(payload.substring(sepIndex + 1)) : NaN;
+    return {
+      type: "detected",
+      phrase,
+      confidence: isNaN(parsed) ? defaultConfidence : parsed,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Split a stdout chunk into complete lines, returning the trailing partial
+ * line so the caller can carry it into the next chunk.
+ */
+export function splitLines(buffer: string): { lines: string[]; rest: string } {
+  const parts = buffer.split("\n");
+  const rest = parts.pop() || "";
+  return { lines: parts, rest };
+}
+
+// -- PowerShell stderr --------------------------------------------------
+
+/**
+ * Extract readable error text from PowerShell's CLIXML stderr wrapper.
+ * Falls back to the raw text with the CLIXML header stripped.
+ */
+export function parsePowerShellError(raw: string): string {
+  const match = raw.match(/<S S="Error">(.+?)<\/S>/s);
+  if (match) {
+    return match[1].replace(/_x000D_/g, "").replace(/&#xA;/g, " ").trim();
+  }
+  return raw.replace(/#< CLIXML\s*/g, "").trim();
+}

--- a/src/windowsSpeechEngine.ts
+++ b/src/windowsSpeechEngine.ts
@@ -1,6 +1,14 @@
 import { EventEmitter } from "events";
 import { spawn, ChildProcess } from "child_process";
 import { ISpeechEngine, WakePhrase } from "./speechEngineInterface";
+import {
+  clampThreshold,
+  matchRoute,
+  normalizePhrases,
+  parseEngineLine,
+  parsePowerShellError,
+  splitLines,
+} from "./wakeWordCore";
 
 /**
  * Speech recognition engine for Windows wake word detection.
@@ -43,10 +51,10 @@ export class WindowsSpeechEngine extends EventEmitter implements ISpeechEngine {
 
     this._killedIntentionally = false;
     this.currentPhrases = phrases;
-    const safeThreshold = Math.max(0.1, Math.min(0.9, Number(confidenceThreshold) || 0.3));
+    const safeThreshold = clampThreshold(confidenceThreshold);
     this.currentThreshold = safeThreshold;
     this.currentDebugMode = debugMode;
-    const phraseStrings = phrases.flatMap((p) => WindowsSpeechEngine.normalizePhrases(p.phrase));
+    const phraseStrings = phrases.flatMap((p) => normalizePhrases(p.phrase));
     const script = this.buildScript(phraseStrings, safeThreshold, debugMode);
     const encoded = Buffer.from(script, "utf16le").toString("base64");
 
@@ -63,31 +71,30 @@ export class WindowsSpeechEngine extends EventEmitter implements ISpeechEngine {
 
     this.process.stdout?.on("data", (data: Buffer) => {
       stdoutBuffer += data.toString();
-      const lines = stdoutBuffer.split("\n");
-      stdoutBuffer = lines.pop() || "";
+      const split = splitLines(stdoutBuffer);
+      stdoutBuffer = split.rest;
 
-      for (const line of lines) {
-        const trimmed = line.trim();
+      for (const line of split.lines) {
+        // A malformed DETECTED line defaults to confidence 0 so it can never
+        // clear the configured threshold.
+        const event = parseEngineLine(line, 0);
+        if (!event) {
+          continue;
+        }
 
-        if (trimmed === "READY") {
+        if (event.type === "ready") {
           this._isListening = true;
           this._isPaused = false;
           this.retryCount = 0;
           this.emit("started");
-        } else if (trimmed.startsWith("DEBUG:")) {
-          this.emit("debug", trimmed.substring(6));
-        } else if (trimmed.startsWith("ERROR:")) {
-          this.emit("error", new Error(trimmed.substring(6)));
-        } else if (trimmed.startsWith("DETECTED:")) {
-          const payload = trimmed.substring(9);
-          const sepIndex = payload.lastIndexOf("|");
-          const detected = (sepIndex >= 0 ? payload.substring(0, sepIndex) : payload).toLowerCase().trim();
-          const confidence = sepIndex >= 0 ? parseFloat(payload.substring(sepIndex + 1)) : 0;
-          const match = phrases.find((p) =>
-            WindowsSpeechEngine.normalizePhrases(p.phrase).includes(detected)
-          );
+        } else if (event.type === "debug") {
+          this.emit("debug", event.message);
+        } else if (event.type === "error") {
+          this.emit("error", new Error(event.message));
+        } else {
+          const match = matchRoute(phrases, event.phrase);
           if (match) {
-            this.emit("detected", match, isNaN(confidence) ? 0 : confidence);
+            this.emit("detected", match, event.confidence);
           }
         }
       }
@@ -126,7 +133,7 @@ export class WindowsSpeechEngine extends EventEmitter implements ISpeechEngine {
 
       // Non-zero exit = crash. Retry or report error.
       if (code !== 0) {
-        const stderrMsg = stderrBuffer.trim() ? this.parseStderr(stderrBuffer) : "";
+        const stderrMsg = stderrBuffer.trim() ? parsePowerShellError(stderrBuffer) : "";
         const msg = stderrMsg || `exit code ${code}`;
 
         if (this.retryCount < WindowsSpeechEngine.MAX_RETRIES) {
@@ -201,22 +208,6 @@ export class WindowsSpeechEngine extends EventEmitter implements ISpeechEngine {
     this.clearRetryTimer();
     this.stop();
     this.removeAllListeners();
-  }
-
-  static normalizePhrases(phrase: string | string[]): string[] {
-    const arr = Array.isArray(phrase) ? phrase : [phrase];
-    return arr.map((p) => p.toLowerCase().trim()).filter((p) => p.length > 0);
-  }
-
-  private parseStderr(raw: string): string {
-    // Extract error text from PowerShell CLIXML wrapper
-    const match = raw.match(/<S S="Error">(.+?)<\/S>/s);
-    if (match) {
-      return match[1].replace(/_x000D_/g, "").replace(/&#xA;/g, " ").trim();
-    }
-
-    // Fall back to raw text, stripping the CLIXML header
-    return raw.replace(/#< CLIXML\s*/g, "").trim();
   }
 
   private clearRetryTimer(): void {

--- a/tests/engine/configParsing.test.js
+++ b/tests/engine/configParsing.test.js
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+import {
+  clampKeywordThreshold,
+  drainLines,
+  parseControlLine,
+} from '../../engine/lib/control.js';
+
+/**
+ * Node delivers stdin in chunks, not lines. The reader used to handle only the
+ * first line of a chunk, so a "stop" that arrived behind anything else was
+ * silently dropped and the child kept running with the microphone open.
+ */
+describe('drainLines', () => {
+  it('returns a single complete line', () => {
+    expect(drainLines('stop\n')).toEqual({ lines: ['stop'], rest: '' });
+  });
+
+  it('returns every complete line in one chunk', () => {
+    expect(drainLines('\nstop\n')).toEqual({ lines: ['', 'stop'], rest: '' });
+  });
+
+  it('returns a config line and a stop that arrived together', () => {
+    expect(drainLines('{"a":1}\nstop\n').lines).toEqual(['{"a":1}', 'stop']);
+  });
+
+  it('keeps a trailing partial line for the next chunk', () => {
+    expect(drainLines('stop\n{"a":')).toEqual({ lines: ['stop'], rest: '{"a":' });
+  });
+
+  it('keeps everything when the chunk holds no newline', () => {
+    expect(drainLines('{"a":')).toEqual({ lines: [], rest: '{"a":' });
+  });
+
+  it('reassembles a config line split across chunks', () => {
+    const first = drainLines('{"threshold":0');
+    const second = drainLines(first.rest + '.3}\n');
+    expect(second.lines).toEqual(['{"threshold":0.3}']);
+    expect(parseControlLine(second.lines[0]).config.threshold).toBe(0.3);
+  });
+
+  it('handles an empty chunk', () => {
+    expect(drainLines('')).toEqual({ lines: [], rest: '' });
+    expect(drainLines(null)).toEqual({ lines: [], rest: '' });
+  });
+});
+
+describe('parseControlLine', () => {
+  it('parses the config JSON the extension sends on start', () => {
+    const line = JSON.stringify({
+      phrases: [{ phrase: 'hey claude', label: 'Claude' }],
+      threshold: 0.3,
+      modelDir: 'C:\\Users\\me\\models',
+      debugMode: false,
+    });
+    const result = parseControlLine(line);
+    expect(result.kind).toBe('config');
+    expect(result.config.phrases).toEqual([{ phrase: 'hey claude', label: 'Claude' }]);
+    expect(result.config.threshold).toBe(0.3);
+    expect(result.config.modelDir).toBe('C:\\Users\\me\\models');
+    expect(result.config.debugMode).toBe(false);
+  });
+
+  it('keeps an alias array intact', () => {
+    const line = JSON.stringify({
+      phrases: [{ phrase: ['hey claude', 'open claude'], label: 'Claude' }],
+    });
+    expect(parseControlLine(line).config.phrases[0].phrase).toEqual([
+      'hey claude',
+      'open claude',
+    ]);
+  });
+
+  it('recognises the stop command', () => {
+    expect(parseControlLine('stop')).toEqual({ kind: 'stop' });
+  });
+
+  it('recognises the stop command with surrounding whitespace', () => {
+    expect(parseControlLine('  stop\r')).toEqual({ kind: 'stop' });
+  });
+
+  it('ignores a blank line', () => {
+    expect(parseControlLine('')).toEqual({ kind: 'empty' });
+    expect(parseControlLine('   ')).toEqual({ kind: 'empty' });
+    expect(parseControlLine('\r')).toEqual({ kind: 'empty' });
+  });
+
+  it('ignores a missing line rather than throwing', () => {
+    expect(parseControlLine(null)).toEqual({ kind: 'empty' });
+    expect(parseControlLine(undefined)).toEqual({ kind: 'empty' });
+  });
+
+  it('reports malformed JSON instead of throwing', () => {
+    const result = parseControlLine('{ not json');
+    expect(result.kind).toBe('invalid');
+    expect(result.message).toMatch(/^Invalid config JSON: /);
+  });
+
+  it('reports a truncated JSON line', () => {
+    expect(parseControlLine('{"phrases":[{"phrase":"hey').kind).toBe('invalid');
+  });
+
+  it('leaves absent fields undefined for the caller to default', () => {
+    const result = parseControlLine('{}');
+    expect(result.kind).toBe('config');
+    expect(result.config.phrases).toBeUndefined();
+    expect(result.config.threshold).toBeUndefined();
+    expect(result.config.modelDir).toBeUndefined();
+  });
+});
+
+describe('clampKeywordThreshold', () => {
+  it('passes an in-range value through', () => {
+    expect(clampKeywordThreshold(0.3)).toBe(0.3);
+    expect(clampKeywordThreshold(0.5)).toBe(0.5);
+  });
+
+  it('clamps to the range sherpa-onnx accepts', () => {
+    expect(clampKeywordThreshold(0.01)).toBe(0.1);
+    expect(clampKeywordThreshold(-1)).toBe(0.1);
+    expect(clampKeywordThreshold(0.95)).toBe(0.9);
+    expect(clampKeywordThreshold(100)).toBe(0.9);
+  });
+
+  it('keeps the bounds themselves', () => {
+    expect(clampKeywordThreshold(0.1)).toBe(0.1);
+    expect(clampKeywordThreshold(0.9)).toBe(0.9);
+  });
+
+  it('defaults when the value is missing or unusable', () => {
+    expect(clampKeywordThreshold(undefined)).toBe(0.25);
+    expect(clampKeywordThreshold(null)).toBe(0.25);
+    expect(clampKeywordThreshold(NaN)).toBe(0.25);
+    expect(clampKeywordThreshold(0)).toBe(0.25);
+  });
+
+  it('never returns a value outside the accepted range', () => {
+    for (const input of [-1, 0, 0.1, 0.25, 0.9, 1, 99, NaN, undefined, null]) {
+      const result = clampKeywordThreshold(input);
+      expect(result).toBeGreaterThanOrEqual(0.1);
+      expect(result).toBeLessThanOrEqual(0.9);
+    }
+  });
+});

--- a/tests/engine/micErrors.test.js
+++ b/tests/engine/micErrors.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { micErrorMessage } from '../../engine/lib/mic-errors.js';
+
+describe('micErrorMessage', () => {
+  it('reports a missing microphone', () => {
+    for (const code of ['NO_MICROPHONE_FOUND', 'MICROPHONE_NOT_FOUND']) {
+      expect(micErrorMessage({ code, message: 'raw' }, 'prefix')).toBe(
+        'No microphone found. Check your audio device settings.'
+      );
+    }
+  });
+
+  it('reports an output device selected as input', () => {
+    expect(micErrorMessage({ code: 'NOT_AN_INPUT_DEVICE' }, 'prefix')).toBe(
+      'The selected audio device is not a microphone. Check your audio device settings.'
+    );
+  });
+
+  it('points at system privacy settings when access is denied', () => {
+    expect(micErrorMessage({ code: 'PERMISSION_DENIED' }, 'prefix')).toBe(
+      'Microphone access denied. Enable microphone access for VS Code in your system privacy settings.'
+    );
+  });
+
+  it('keeps the underlying message for a device failure', () => {
+    expect(
+      micErrorMessage({ code: 'DEVICE_FAILED', message: 'stream closed' }, 'prefix')
+    ).toBe('The microphone stopped responding: stream closed');
+  });
+
+  it('groups the onnxruntime and VAD load failures under one message', () => {
+    const codes = [
+      'ORT_INIT_FAILED',
+      'ORT_LOAD_FAILED',
+      'ORT_SESSION_BUILD_FAILED',
+      'ORT_INFERENCE_FAILED',
+      'VAD_MODEL_LOAD_FAILED',
+    ];
+    for (const code of codes) {
+      expect(micErrorMessage({ code, message: 'silero.onnx missing' }, 'prefix')).toBe(
+        'Failed to start voice activity detection: silero.onnx missing'
+      );
+    }
+  });
+
+  it('falls back to the caller prefix for an unknown code', () => {
+    expect(
+      micErrorMessage({ code: 'SOMETHING_NEW', message: 'boom' }, 'Microphone error')
+    ).toBe('Microphone error: boom');
+  });
+
+  it('falls back for a plain Error with no code', () => {
+    expect(micErrorMessage(new Error('boom'), 'Failed to open microphone')).toBe(
+      'Failed to open microphone: boom'
+    );
+  });
+
+  it('does not throw on a non-error value', () => {
+    expect(micErrorMessage('just a string', 'prefix')).toBe('prefix: just a string');
+    expect(micErrorMessage(null, 'prefix')).toBe('prefix: null');
+    expect(micErrorMessage(undefined, 'prefix')).toBe('prefix: undefined');
+  });
+
+  it('never returns an empty message', () => {
+    const inputs = [null, undefined, {}, new Error(''), { code: 'PERMISSION_DENIED' }];
+    for (const input of inputs) {
+      expect(micErrorMessage(input, 'prefix').length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/engine/modelPath.test.js
+++ b/tests/engine/modelPath.test.js
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { modelPath } from '../../engine/lib/model-path.js';
+
+/**
+ * D14. sherpa-onnx is an Emscripten build: a path that does not start with '/'
+ * is resolved against the WASM working directory, so a Windows absolute path
+ * with backslashes is never found. createKws() then returns a handle that dies
+ * with "null function or function signature mismatch" on first use, which is
+ * why the failure did not look like a path problem.
+ */
+describe('modelPath', () => {
+  it('converts a Windows absolute path to forward slashes', () => {
+    expect(modelPath('C:\\Users\\foo\\bar', 'tokens.txt')).toBe(
+      'C:/Users/foo/bar/tokens.txt'
+    );
+  });
+
+  it('leaves a POSIX absolute path alone', () => {
+    expect(modelPath('/home/foo/bar', 'tokens.txt')).toBe('/home/foo/bar/tokens.txt');
+  });
+
+  it('normalises mixed separators', () => {
+    expect(modelPath('C:\\Users/foo\\bar', 'tokens.txt')).toBe(
+      'C:/Users/foo/bar/tokens.txt'
+    );
+  });
+
+  it('handles a trailing separator', () => {
+    expect(modelPath('C:\\Users\\foo\\', 'tokens.txt')).toBe('C:/Users/foo/tokens.txt');
+    expect(modelPath('/home/foo/', 'tokens.txt')).toBe('/home/foo/tokens.txt');
+  });
+
+  it('handles an empty model directory', () => {
+    expect(modelPath('', 'tokens.txt')).toBe('tokens.txt');
+  });
+
+  it('never emits a backslash, whatever the input', () => {
+    const inputs = [
+      'C:\\Users\\me\\AppData\\Roaming\\Code\\User\\globalStorage',
+      '\\\\server\\share\\models',
+      '/Users/me/Library/Application Support/Code',
+      'relative\\dir',
+      'relative/dir',
+    ];
+    for (const dir of inputs) {
+      expect(modelPath(dir, 'bpe.model')).not.toContain('\\');
+    }
+  });
+
+  it('produces the same result for the same logical path either way round', () => {
+    expect(modelPath('C:\\models\\kws', 'encoder.onnx')).toBe(
+      modelPath('C:/models/kws', 'encoder.onnx')
+    );
+  });
+
+  it('covers every model file the engine opens', () => {
+    const files = [
+      'encoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx',
+      'decoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx',
+      'joiner-epoch-12-avg-2-chunk-16-left-64.int8.onnx',
+      'tokens.txt',
+      'bpe.model',
+    ];
+    const dir = 'C:\\Users\\me\\AppData\\Roaming\\Code\\User\\globalStorage\\sherpa-onnx';
+    for (const f of files) {
+      const p = modelPath(dir, f);
+      expect(p).not.toContain('\\');
+      expect(p.endsWith('/' + f)).toBe(true);
+    }
+  });
+});

--- a/tests/engine/preroll.test.js
+++ b/tests/engine/preroll.test.js
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { VadGate } from '../../engine/lib/vad-gate.js';
+
+/**
+ * decibri emits 'data' for a chunk before it scores that chunk, so the chunk
+ * that trips the speech detector arrives while the gate is still closed. If
+ * that lead-in is dropped, the onset of the wake phrase never reaches the
+ * keyword spotter and detection collapses. These tests pin the ordering and
+ * the ring size.
+ */
+describe('VadGate pre-roll ring', () => {
+  it('starts closed and empty', () => {
+    const gate = new VadGate(5);
+    expect(gate.speaking).toBe(false);
+    expect(gate.prerollLength).toBe(0);
+  });
+
+  it('holds chunks instead of feeding them while silent', () => {
+    const gate = new VadGate(5);
+    expect(gate.push('a')).toEqual([]);
+    expect(gate.push('b')).toEqual([]);
+    expect(gate.prerollLength).toBe(2);
+  });
+
+  it('holds at most N chunks', () => {
+    const gate = new VadGate(5);
+    for (const c of ['a', 'b', 'c', 'd', 'e', 'f', 'g']) {
+      gate.push(c);
+    }
+    expect(gate.prerollLength).toBe(5);
+  });
+
+  it('drops the oldest chunk once the ring is full', () => {
+    const gate = new VadGate(3);
+    ['a', 'b', 'c', 'd'].forEach((c) => gate.push(c));
+    expect(gate.speechStarted()).toEqual(['b', 'c', 'd']);
+  });
+
+  it('flushes the pre-roll in arrival order', () => {
+    const gate = new VadGate(5);
+    ['a', 'b', 'c'].forEach((c) => gate.push(c));
+    expect(gate.speechStarted()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('empties the ring on flush', () => {
+    const gate = new VadGate(5);
+    ['a', 'b'].forEach((c) => gate.push(c));
+    gate.speechStarted();
+    expect(gate.prerollLength).toBe(0);
+    expect(gate.speechStarted()).toEqual([]);
+  });
+
+  it('feeds chunks straight through once speaking', () => {
+    const gate = new VadGate(5);
+    gate.speechStarted();
+    expect(gate.push('x')).toEqual(['x']);
+    expect(gate.push('y')).toEqual(['y']);
+    expect(gate.prerollLength).toBe(0);
+  });
+
+  it('discards the pre-roll on silence', () => {
+    const gate = new VadGate(5);
+    ['a', 'b'].forEach((c) => gate.push(c));
+    gate.speechEnded();
+    expect(gate.prerollLength).toBe(0);
+    expect(gate.speaking).toBe(false);
+  });
+
+  it('buffers again after silence', () => {
+    const gate = new VadGate(5);
+    gate.speechStarted();
+    gate.speechEnded();
+    expect(gate.push('a')).toEqual([]);
+    expect(gate.prerollLength).toBe(1);
+  });
+
+  it('survives repeated speech and silence cycles', () => {
+    const gate = new VadGate(2);
+    const fed = [];
+    const drive = (events) => {
+      for (const e of events) {
+        if (e === 'speech') {
+          fed.push(...gate.speechStarted());
+        } else if (e === 'silence') {
+          gate.speechEnded();
+        } else {
+          fed.push(...gate.push(e));
+        }
+      }
+    };
+
+    // Two utterances separated by silence, each with lead-in chunks that the
+    // VAD only scores after they have been delivered.
+    drive(['s1', 's2', 'speech', 'w1', 'w2', 'silence']);
+    drive(['q1', 'q2', 'q3', 'speech', 'w3', 'silence']);
+
+    // The second utterance had three chunks of lead-in, so the 2-chunk ring
+    // evicted 'q1'. Everything else reaches the spotter in arrival order.
+    expect(fed).toEqual(['s1', 's2', 'w1', 'w2', 'q2', 'q3', 'w3']);
+  });
+
+  it('delivers the chunk that tripped the detector before anything captured later', () => {
+    // This is the ordering the pre-roll exists for: the onset chunk was
+    // already handed to the data handler before 'speech' fired.
+    const gate = new VadGate(5);
+    const fed = [];
+    fed.push(...gate.push('onset'));
+    fed.push(...gate.speechStarted());
+    fed.push(...gate.push('rest'));
+    expect(fed).toEqual(['onset', 'rest']);
+  });
+
+  it('never feeds a chunk twice', () => {
+    const gate = new VadGate(5);
+    const fed = [];
+    fed.push(...gate.push('a'));
+    fed.push(...gate.speechStarted());
+    fed.push(...gate.speechStarted());
+    fed.push(...gate.push('b'));
+    expect(fed).toEqual(['a', 'b']);
+  });
+
+  it('preserves chunk identity, not a copy', () => {
+    const gate = new VadGate(5);
+    const chunk = new Float32Array([0.1, 0.2]);
+    gate.push(chunk);
+    expect(gate.speechStarted()[0]).toBe(chunk);
+  });
+
+  it('treats a zero or invalid ring size as no pre-roll', () => {
+    for (const size of [0, -1, NaN, undefined, null, 'five']) {
+      const gate = new VadGate(size);
+      expect(gate.push('a')).toEqual([]);
+      expect(gate.prerollLength).toBe(0);
+      expect(gate.speechStarted()).toEqual([]);
+    }
+  });
+
+  it('resets to the initial state', () => {
+    const gate = new VadGate(5);
+    gate.push('a');
+    gate.speechStarted();
+    gate.push('b');
+    gate.reset();
+    expect(gate.speaking).toBe(false);
+    expect(gate.prerollLength).toBe(0);
+  });
+});

--- a/tests/engine/tokenisation.test.js
+++ b/tests/engine/tokenisation.test.js
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import {
+  WORD_BOUNDARY,
+  buildKeywordSpec,
+  decodePieces,
+} from '../../engine/lib/keywords.js';
+
+const B = WORD_BOUNDARY;
+
+/**
+ * A stand-in for SentencePieceProcessor.encodePieces that splits on spaces,
+ * marks each word boundary the way the real BPE model does, and breaks longer
+ * words into two pieces. The round trip (encode, then decode the pieces) is
+ * what has to agree with the string sherpa-onnx reports on a hit, so the shape
+ * of the pieces matters more than the exact vocabulary.
+ *
+ *   "HEY CLAUDE" -> ["<B>HE", "Y", "<B>CL", "AUDE"]
+ */
+function fakeEncodePieces(text) {
+  return text
+    .split(/\s+/)
+    .filter(Boolean)
+    .flatMap((word) => {
+      const head = B + word.slice(0, 2);
+      const tail = word.slice(2);
+      return tail ? [head, tail] : [head];
+    });
+}
+
+describe('decodePieces', () => {
+  it('turns the boundary marker back into a space', () => {
+    expect(decodePieces([B + 'HEY', B + 'CLAUDE'])).toBe('HEY CLAUDE');
+  });
+
+  it('joins sub-word pieces without a space', () => {
+    expect(decodePieces([B + 'CL', 'AU', 'DE'])).toBe('CLAUDE');
+  });
+
+  it('trims the leading boundary of the first piece', () => {
+    expect(decodePieces([B + 'COMPUTER'])).toBe('COMPUTER');
+  });
+
+  it('returns an empty string for no pieces', () => {
+    expect(decodePieces([])).toBe('');
+  });
+
+  it('handles pieces with no boundary marker at all', () => {
+    expect(decodePieces(['HE', 'Y'])).toBe('HEY');
+  });
+
+  it('round-trips a multi-word phrase through the fake tokeniser', () => {
+    expect(decodePieces(fakeEncodePieces('HEY CLAUDE'))).toBe('HEY CLAUDE');
+    expect(decodePieces(fakeEncodePieces('COMPUTER'))).toBe('COMPUTER');
+    expect(decodePieces(fakeEncodePieces('  HEY   COPILOT  '))).toBe('HEY COPILOT');
+  });
+});
+
+describe('buildKeywordSpec', () => {
+  it('maps the decoded keyword back to the spoken phrase', () => {
+    const spec = buildKeywordSpec(
+      [{ phrase: 'Hey Claude', label: 'Claude' }],
+      fakeEncodePieces
+    );
+    // sherpa-onnx reports the decoded form; the map turns it back into what
+    // the routing table matches on.
+    expect(spec.phraseMap['HEY CLAUDE']).toBe('hey claude');
+  });
+
+  it('emits one keyword line per phrase', () => {
+    const spec = buildKeywordSpec(
+      [
+        { phrase: 'hey claude', label: 'Claude' },
+        { phrase: 'computer', label: 'Terminal' },
+      ],
+      fakeEncodePieces
+    );
+    expect(spec.keywordLines).toHaveLength(2);
+    expect(spec.keywords.split('\n')).toHaveLength(2);
+  });
+
+  it('expands an alias array into one line each', () => {
+    const spec = buildKeywordSpec(
+      [{ phrase: ['hey claude', 'open claude'], label: 'Claude' }],
+      fakeEncodePieces
+    );
+    expect(spec.keywordLines).toHaveLength(2);
+    expect(spec.phraseMap['HEY CLAUDE']).toBe('hey claude');
+    expect(spec.phraseMap['OPEN CLAUDE']).toBe('open claude');
+  });
+
+  it('tokenises the uppercased phrase but maps back to lowercase', () => {
+    const spec = buildKeywordSpec(
+      [{ phrase: '  Hey CLAUDE  ', label: 'Claude' }],
+      fakeEncodePieces
+    );
+    expect(Object.keys(spec.phraseMap)).toEqual(['HEY CLAUDE']);
+    expect(spec.phraseMap['HEY CLAUDE']).toBe('hey claude');
+  });
+
+  it('writes keyword lines as space-separated pieces', () => {
+    const spec = buildKeywordSpec([{ phrase: 'hey', label: 'X' }], fakeEncodePieces);
+    expect(spec.keywordLines).toEqual([B + 'HE Y']);
+    expect(spec.keywords).toBe(B + 'HE Y');
+  });
+
+  it('separates keyword lines with a newline, as sherpa-onnx expects', () => {
+    const spec = buildKeywordSpec(
+      [
+        { phrase: 'hey', label: 'A' },
+        { phrase: 'yo', label: 'B' },
+      ],
+      fakeEncodePieces
+    );
+    expect(spec.keywords).toBe(B + 'HE Y' + '\n' + B + 'YO');
+  });
+
+  it('skips blank phrases', () => {
+    const spec = buildKeywordSpec(
+      [{ phrase: ['hey claude', '', '   '], label: 'Claude' }],
+      fakeEncodePieces
+    );
+    expect(spec.keywordLines).toHaveLength(1);
+  });
+
+  it('skips non-string phrases instead of throwing', () => {
+    const spec = buildKeywordSpec(
+      [{ phrase: ['hey claude', 42, null], label: 'Claude' }, null, undefined],
+      fakeEncodePieces
+    );
+    expect(spec.keywordLines).toHaveLength(1);
+    expect(spec.phraseMap['HEY CLAUDE']).toBe('hey claude');
+  });
+
+  it('returns an empty spec for no phrases, which the engine reports as fatal', () => {
+    for (const input of [[], null, undefined]) {
+      const spec = buildKeywordSpec(input, fakeEncodePieces);
+      expect(spec.keywordLines).toHaveLength(0);
+      expect(spec.keywords).toBe('');
+      expect(spec.phraseMap).toEqual({});
+    }
+  });
+
+  it('reports the tokenisation of each phrase for the debug log', () => {
+    const spec = buildKeywordSpec(
+      [{ phrase: 'hey claude', label: 'Claude' }],
+      fakeEncodePieces
+    );
+    expect(spec.details).toEqual([
+      {
+        phrase: 'hey claude',
+        tokens: spec.keywordLines[0],
+        decoded: 'HEY CLAUDE',
+      },
+    ]);
+  });
+
+  it('drops a phrase whose tokenisation decodes to nothing', () => {
+    const spec = buildKeywordSpec([{ phrase: 'hey claude', label: 'Claude' }], () => []);
+    expect(spec.keywordLines).toHaveLength(0);
+  });
+
+  it('collapses case-different duplicates onto one map entry', () => {
+    // Two routes listening for the same words still produce two keyword lines
+    // (harmless: sherpa-onnx accepts the repeat) but only one lookup key, so
+    // the first route configured is the one that fires.
+    const spec = buildKeywordSpec(
+      [
+        { phrase: 'hey claude', label: 'Claude' },
+        { phrase: 'HEY CLAUDE', label: 'Claude Again' },
+      ],
+      fakeEncodePieces
+    );
+    expect(Object.keys(spec.phraseMap)).toEqual(['HEY CLAUDE']);
+    expect(spec.phraseMap['HEY CLAUDE']).toBe('hey claude');
+    expect(spec.keywordLines).toHaveLength(2);
+  });
+
+  it('keeps every decoded key reachable from the spotter output', () => {
+    const spec = buildKeywordSpec(
+      [
+        { phrase: 'hey claude', label: 'Claude' },
+        { phrase: 'hey copilot', label: 'Copilot' },
+        { phrase: 'computer', label: 'Terminal' },
+      ],
+      fakeEncodePieces
+    );
+    for (const line of spec.keywordLines) {
+      const decoded = decodePieces(line.split(' '));
+      expect(spec.phraseMap[decoded]).toBeDefined();
+    }
+  });
+});

--- a/tests/mocks/vscode.ts
+++ b/tests/mocks/vscode.ts
@@ -1,0 +1,66 @@
+/**
+ * Minimal stand-in for the `vscode` module.
+ *
+ * The real module only exists inside the extension host. Unit tests never call
+ * into the VS Code API: this stub exists so that importing a src module which
+ * declares `import * as vscode from "vscode"` resolves. Anything a test does
+ * reach for should be stubbed per-test with `vi.spyOn`, not added here.
+ */
+
+export const version = "0.0.0-test";
+
+export enum StatusBarAlignment {
+  Left = 1,
+  Right = 2,
+}
+
+export enum ExtensionMode {
+  Production = 1,
+  Development = 2,
+  Test = 3,
+}
+
+export enum ProgressLocation {
+  SourceControl = 1,
+  Window = 10,
+  Notification = 15,
+}
+
+export class ThemeColor {
+  constructor(public readonly id: string) {}
+}
+
+export class Uri {
+  private constructor(public readonly fsPath: string) {}
+  static file(p: string): Uri {
+    return new Uri(p);
+  }
+}
+
+function notImplemented(name: string): never {
+  throw new Error(
+    `vscode.${name} was called in a unit test. Unit tests must not touch the ` +
+      `VS Code API; stub it explicitly or move the logic under test into a ` +
+      `pure module.`
+  );
+}
+
+export const window = {
+  createOutputChannel: () => notImplemented("window.createOutputChannel"),
+  createStatusBarItem: () => notImplemented("window.createStatusBarItem"),
+  showInformationMessage: () => notImplemented("window.showInformationMessage"),
+  showWarningMessage: () => notImplemented("window.showWarningMessage"),
+  showErrorMessage: () => notImplemented("window.showErrorMessage"),
+  withProgress: () => notImplemented("window.withProgress"),
+  onDidChangeWindowState: () => notImplemented("window.onDidChangeWindowState"),
+};
+
+export const workspace = {
+  getConfiguration: () => notImplemented("workspace.getConfiguration"),
+  onDidChangeConfiguration: () => notImplemented("workspace.onDidChangeConfiguration"),
+};
+
+export const commands = {
+  registerCommand: () => notImplemented("commands.registerCommand"),
+  executeCommand: () => notImplemented("commands.executeCommand"),
+};

--- a/tests/unit/debounce.test.ts
+++ b/tests/unit/debounce.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { DETECTION_DEBOUNCE_MS, shouldDebounce } from "../../src/wakeWordCore";
+
+describe("shouldDebounce", () => {
+  it("uses a 3 second window by default", () => {
+    expect(DETECTION_DEBOUNCE_MS).toBe(3000);
+  });
+
+  it("never suppresses the first detection", () => {
+    // lastDetectionTime is 0 until something is detected, and Date.now() is
+    // always far past the window.
+    expect(shouldDebounce(Date.now(), 0)).toBe(false);
+  });
+
+  it("suppresses a repeat inside the window", () => {
+    expect(shouldDebounce(1_000_000, 999_000)).toBe(true);
+  });
+
+  it("suppresses an immediate repeat", () => {
+    expect(shouldDebounce(1_000_000, 1_000_000)).toBe(true);
+  });
+
+  it("allows a detection after the window", () => {
+    expect(shouldDebounce(1_003_001, 1_000_000)).toBe(false);
+  });
+
+  it("allows a detection exactly on the boundary", () => {
+    // The guard is `now - last < window`, so a gap of exactly the window
+    // passes through.
+    expect(shouldDebounce(1_003_000, 1_000_000)).toBe(false);
+  });
+
+  it("suppresses one millisecond before the boundary", () => {
+    expect(shouldDebounce(1_002_999, 1_000_000)).toBe(true);
+  });
+
+  it("clears the guard when the timestamp is reset to 0", () => {
+    // resumeListening() and stopListening() reset lastDetectionTime to 0 so
+    // the phrase can fire again the moment listening comes back.
+    expect(shouldDebounce(1_000_500, 1_000_000)).toBe(true);
+    expect(shouldDebounce(1_000_500, 0)).toBe(false);
+  });
+
+  it("honours a custom window", () => {
+    expect(shouldDebounce(1_005_000, 1_000_000, 10_000)).toBe(true);
+    expect(shouldDebounce(1_005_000, 1_000_000, 1_000)).toBe(false);
+  });
+
+  it("suppresses while the wall clock is behind the last detection", () => {
+    // Documented behaviour, not an accident: a backwards clock step makes the
+    // delta negative, which reads as "inside the window". Detections stay
+    // suppressed until the clock passes the recorded time again. The guard is
+    // cleared on pause and resume, so this cannot latch for longer than one
+    // cooldown.
+    expect(shouldDebounce(1_000_000, 2_000_000)).toBe(true);
+    expect(shouldDebounce(2_000_001, 2_000_000)).toBe(true);
+  });
+
+  it("models a full detect, cooldown, detect cycle", () => {
+    let last = 0;
+    const accept = (now: number): boolean => {
+      if (shouldDebounce(now, last)) {
+        return false;
+      }
+      last = now;
+      return true;
+    };
+
+    expect(accept(10_000)).toBe(true); // first wake phrase
+    expect(accept(10_500)).toBe(false); // engine repeats the same detection
+    expect(accept(12_999)).toBe(false); // still inside the window
+    expect(accept(13_000)).toBe(true); // window elapsed
+  });
+});

--- a/tests/unit/engineSelection.test.ts
+++ b/tests/unit/engineSelection.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  MAX_THRESHOLD,
+  MIN_THRESHOLD,
+  clampThreshold,
+  parsePowerShellError,
+  selectEngineKind,
+} from "../../src/wakeWordCore";
+
+describe("selectEngineKind", () => {
+  it("picks the Windows engine on Windows under auto", () => {
+    expect(selectEngineKind("auto", "win32")).toBe("windows");
+  });
+
+  it("picks sherpa on macOS and Linux under auto", () => {
+    expect(selectEngineKind("auto", "darwin")).toBe("sherpa");
+    expect(selectEngineKind("auto", "linux")).toBe("sherpa");
+  });
+
+  it("honours an explicit sherpa override on Windows", () => {
+    expect(selectEngineKind("sherpa", "win32")).toBe("sherpa");
+  });
+
+  it("honours an explicit windows override", () => {
+    expect(selectEngineKind("windows", "win32")).toBe("windows");
+  });
+
+  // Known limitation, tracked in the relay report: forcing "windows" off
+  // Windows is honoured and then fails at spawn time with an ENOENT for
+  // powershell.exe. The setting is documented as Windows only.
+  it("honours a windows override even where PowerShell does not exist", () => {
+    expect(selectEngineKind("windows", "darwin")).toBe("windows");
+    expect(selectEngineKind("windows", "linux")).toBe("windows");
+  });
+
+  it("treats an unknown setting value as auto", () => {
+    expect(selectEngineKind("nonsense", "win32")).toBe("windows");
+    expect(selectEngineKind("nonsense", "darwin")).toBe("sherpa");
+    expect(selectEngineKind("", "linux")).toBe("sherpa");
+  });
+
+  it("covers every platform the extension builds for", () => {
+    expect(selectEngineKind("auto", "win32")).toBe("windows");
+    expect(selectEngineKind("auto", "darwin")).toBe("sherpa");
+    expect(selectEngineKind("auto", "linux")).toBe("sherpa");
+    expect(selectEngineKind("auto", "freebsd")).toBe("sherpa");
+  });
+});
+
+describe("clampThreshold", () => {
+  it("passes an in-range value through", () => {
+    expect(clampThreshold(0.5)).toBe(0.5);
+  });
+
+  it("clamps below the minimum", () => {
+    expect(clampThreshold(-5)).toBe(MIN_THRESHOLD);
+    expect(clampThreshold(0.01)).toBe(MIN_THRESHOLD);
+  });
+
+  it("clamps above the maximum", () => {
+    expect(clampThreshold(5)).toBe(MAX_THRESHOLD);
+    expect(clampThreshold(0.95)).toBe(MAX_THRESHOLD);
+  });
+
+  it("keeps the range bounds themselves", () => {
+    expect(clampThreshold(MIN_THRESHOLD)).toBe(MIN_THRESHOLD);
+    expect(clampThreshold(MAX_THRESHOLD)).toBe(MAX_THRESHOLD);
+  });
+
+  it("falls back to the default for values that are not usable numbers", () => {
+    expect(clampThreshold(undefined)).toBe(0.3);
+    expect(clampThreshold(null)).toBe(0.3);
+    expect(clampThreshold(NaN)).toBe(0.3);
+    expect(clampThreshold("not a number")).toBe(0.3);
+    expect(clampThreshold(0)).toBe(0.3);
+  });
+
+  it("coerces a numeric string", () => {
+    expect(clampThreshold("0.6")).toBe(0.6);
+  });
+
+  it("honours a caller-supplied fallback", () => {
+    expect(clampThreshold(undefined, 0.25)).toBe(0.25);
+  });
+
+  it("never returns a value outside the settings range", () => {
+    const inputs = [-1, 0, 0.1, 0.3, 0.9, 1, 100, NaN, "x", null, undefined];
+    for (const input of inputs) {
+      const result = clampThreshold(input);
+      expect(result).toBeGreaterThanOrEqual(MIN_THRESHOLD);
+      expect(result).toBeLessThanOrEqual(MAX_THRESHOLD);
+    }
+  });
+});
+
+describe("parsePowerShellError", () => {
+  it("extracts the message from a CLIXML error record", () => {
+    const raw =
+      '#< CLIXML\n<Objs Version="1.1.0.1"><S S="Error">' +
+      "Exception calling SetInputToDefaultAudioDevice_x000D__x000D_" +
+      "</S></Objs>";
+    expect(parsePowerShellError(raw)).toBe(
+      "Exception calling SetInputToDefaultAudioDevice"
+    );
+  });
+
+  it("turns encoded newlines into spaces", () => {
+    const raw = '<S S="Error">first line&#xA;second line</S>';
+    expect(parsePowerShellError(raw)).toBe("first line second line");
+  });
+
+  it("matches across real newlines inside the record", () => {
+    const raw = '<S S="Error">first\nsecond</S>';
+    expect(parsePowerShellError(raw)).toBe("first\nsecond");
+  });
+
+  it("falls back to the raw text with the CLIXML header stripped", () => {
+    expect(parsePowerShellError("#< CLIXML\nsomething went wrong")).toBe(
+      "something went wrong"
+    );
+  });
+
+  it("returns plain stderr unchanged apart from trimming", () => {
+    expect(parsePowerShellError("  plain failure  ")).toBe("plain failure");
+  });
+
+  it("returns an empty string for empty input", () => {
+    expect(parsePowerShellError("")).toBe("");
+  });
+});

--- a/tests/unit/findSystemNode.test.ts
+++ b/tests/unit/findSystemNode.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  execSync: vi.fn(),
+  existsSync: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  execSync: mocks.execSync,
+  spawn: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  existsSync: mocks.existsSync,
+  mkdirSync: vi.fn(),
+  createWriteStream: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+import { findSystemNode } from "../../src/sherpaEngine";
+
+const realPlatform = process.platform;
+
+function setPlatform(platform: string): void {
+  Object.defineProperty(process, "platform", {
+    value: platform,
+    configurable: true,
+  });
+}
+
+describe("findSystemNode", () => {
+  beforeEach(() => {
+    mocks.execSync.mockReset();
+    mocks.existsSync.mockReset();
+    mocks.existsSync.mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    setPlatform(realPlatform);
+  });
+
+  it("returns the user override without probing anything", () => {
+    setPlatform("darwin");
+    expect(findSystemNode("/Users/me/.nvm/versions/node/v20.11.0/bin/node")).toBe(
+      "/Users/me/.nvm/versions/node/v20.11.0/bin/node"
+    );
+    expect(mocks.execSync).not.toHaveBeenCalled();
+    expect(mocks.existsSync).not.toHaveBeenCalled();
+  });
+
+  it("falls through to the shell lookup when the override is empty", () => {
+    setPlatform("linux");
+    mocks.execSync.mockReturnValue("/usr/bin/node\n");
+    expect(findSystemNode("")).toBe("/usr/bin/node");
+    expect(mocks.execSync).toHaveBeenCalledWith("which node", { encoding: "utf8" });
+  });
+
+  it("falls through to the shell lookup when no override is passed", () => {
+    setPlatform("linux");
+    mocks.execSync.mockReturnValue("/usr/bin/node\n");
+    expect(findSystemNode()).toBe("/usr/bin/node");
+  });
+
+  it("uses `where node` on Windows", () => {
+    setPlatform("win32");
+    mocks.execSync.mockReturnValue("C:\\Program Files\\nodejs\\node.exe\r\n");
+    expect(findSystemNode()).toBe("C:\\Program Files\\nodejs\\node.exe");
+    expect(mocks.execSync).toHaveBeenCalledWith("where node", { encoding: "utf8" });
+  });
+
+  it("takes the first result when `where node` returns several", () => {
+    setPlatform("win32");
+    mocks.execSync.mockReturnValue(
+      "C:\\Program Files\\nodejs\\node.exe\r\nC:\\Users\\me\\scoop\\node.exe\r\n"
+    );
+    expect(findSystemNode()).toBe("C:\\Program Files\\nodejs\\node.exe");
+  });
+
+  it("falls through when the shell lookup throws", () => {
+    setPlatform("linux");
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("Command failed: which node");
+    });
+    mocks.existsSync.mockImplementation((p: string) => p === "/usr/bin/node");
+    expect(findSystemNode()).toBe("/usr/bin/node");
+  });
+
+  it("falls through when the shell lookup returns nothing", () => {
+    setPlatform("linux");
+    mocks.execSync.mockReturnValue("   \n");
+    mocks.existsSync.mockImplementation((p: string) => p === "/usr/local/bin/node");
+    expect(findSystemNode()).toBe("/usr/local/bin/node");
+  });
+
+  it("probes the Windows well-known path", () => {
+    setPlatform("win32");
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    mocks.existsSync.mockImplementation(
+      (p: string) => p === "C:\\Program Files\\nodejs\\node.exe"
+    );
+    expect(findSystemNode()).toBe("C:\\Program Files\\nodejs\\node.exe");
+  });
+
+  it("prefers Homebrew over /usr/local on macOS", () => {
+    setPlatform("darwin");
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    mocks.existsSync.mockReturnValue(true);
+    expect(findSystemNode()).toBe("/opt/homebrew/bin/node");
+  });
+
+  it("falls back to /usr/local on an Intel Mac without Homebrew ARM paths", () => {
+    setPlatform("darwin");
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    mocks.existsSync.mockImplementation((p: string) => p === "/usr/local/bin/node");
+    expect(findSystemNode()).toBe("/usr/local/bin/node");
+  });
+
+  it("prefers /usr/bin over /usr/local on Linux", () => {
+    setPlatform("linux");
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    mocks.existsSync.mockReturnValue(true);
+    expect(findSystemNode()).toBe("/usr/bin/node");
+  });
+
+  it("returns bare 'node' as a last resort", () => {
+    for (const platform of ["win32", "darwin", "linux"]) {
+      mocks.execSync.mockImplementation(() => {
+        throw new Error("not found");
+      });
+      mocks.existsSync.mockReturnValue(false);
+      setPlatform(platform);
+      expect(findSystemNode()).toBe("node");
+    }
+  });
+
+  it("never probes the wrong platform's well-known paths", () => {
+    setPlatform("darwin");
+    mocks.execSync.mockImplementation(() => {
+      throw new Error("not found");
+    });
+    mocks.existsSync.mockReturnValue(false);
+    findSystemNode();
+    const probed = mocks.existsSync.mock.calls.map((c) => c[0]);
+    expect(probed).toEqual(["/opt/homebrew/bin/node", "/usr/local/bin/node"]);
+  });
+});

--- a/tests/unit/modelDownload.test.ts
+++ b/tests/unit/modelDownload.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("child_process", () => ({ execSync: vi.fn(), spawn: vi.fn() }));
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  createWriteStream: vi.fn(),
+  writeFileSync: vi.fn(),
+  readFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+import { shouldFollowRedirect } from "../../src/sherpaEngine";
+
+describe("shouldFollowRedirect", () => {
+  it("follows the 302 GitHub returns for a release asset", () => {
+    expect(
+      shouldFollowRedirect(302, "https://objects.githubusercontent.com/kws-models.tar.bz2")
+    ).toBe(true);
+  });
+
+  it("follows every 3xx that carries a location", () => {
+    for (const code of [300, 301, 302, 303, 307, 308]) {
+      expect(shouldFollowRedirect(code, "https://cdn.example/model")).toBe(true);
+    }
+  });
+
+  it("does not follow a 3xx without a location header", () => {
+    // Node reports a missing header as undefined. Following it would recurse
+    // into https.get(undefined) rather than surfacing the bad response.
+    expect(shouldFollowRedirect(302, undefined)).toBe(false);
+    expect(shouldFollowRedirect(302, "")).toBe(false);
+  });
+
+  it("does not follow a success response", () => {
+    expect(shouldFollowRedirect(200, "https://cdn.example/model")).toBe(false);
+    expect(shouldFollowRedirect(204, undefined)).toBe(false);
+  });
+
+  it("does not follow an error response", () => {
+    expect(shouldFollowRedirect(404, "https://cdn.example/model")).toBe(false);
+    expect(shouldFollowRedirect(500, undefined)).toBe(false);
+  });
+
+  it("does not follow a response with no status code", () => {
+    expect(shouldFollowRedirect(undefined, "https://cdn.example/model")).toBe(false);
+  });
+});

--- a/tests/unit/normalizePhrases.test.ts
+++ b/tests/unit/normalizePhrases.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { matchRoute, normalizePhrases } from "../../src/wakeWordCore";
+import type { WakePhrase } from "../../src/speechEngineInterface";
+
+describe("normalizePhrases", () => {
+  it("wraps a single string in an array", () => {
+    expect(normalizePhrases("hey claude")).toEqual(["hey claude"]);
+  });
+
+  it("lowercases and trims a single string", () => {
+    expect(normalizePhrases("  Hey CLAUDE  ")).toEqual(["hey claude"]);
+  });
+
+  it("normalises every entry of an array", () => {
+    expect(normalizePhrases([" Hey Claude ", "OPEN Claude"])).toEqual([
+      "hey claude",
+      "open claude",
+    ]);
+  });
+
+  it("drops empty strings", () => {
+    expect(normalizePhrases(["hey claude", ""])).toEqual(["hey claude"]);
+  });
+
+  it("drops whitespace-only strings", () => {
+    expect(normalizePhrases(["hey claude", "   ", "\t\n"])).toEqual(["hey claude"]);
+  });
+
+  it("returns an empty array when nothing survives", () => {
+    expect(normalizePhrases(["", "  "])).toEqual([]);
+    expect(normalizePhrases("")).toEqual([]);
+    expect(normalizePhrases([])).toEqual([]);
+  });
+
+  it("does not collapse inner whitespace", () => {
+    expect(normalizePhrases(" hey   claude ")).toEqual(["hey   claude"]);
+  });
+
+  // wakeWord.routes is user-edited JSON and VS Code does not enforce the
+  // contributed schema, so a non-string in the array must not throw during
+  // activation. Before the guard this raised "p.toLowerCase is not a function".
+  it("skips non-string entries instead of throwing", () => {
+    const mixed = ["hey claude", 42, null, undefined, { phrase: "x" }, true];
+    expect(() => normalizePhrases(mixed)).not.toThrow();
+    expect(normalizePhrases(mixed)).toEqual(["hey claude"]);
+  });
+
+  it("returns an empty array for a non-string scalar", () => {
+    expect(normalizePhrases(42)).toEqual([]);
+    expect(normalizePhrases(null)).toEqual([]);
+    expect(normalizePhrases(undefined)).toEqual([]);
+  });
+});
+
+describe("matchRoute", () => {
+  const routes: WakePhrase[] = [
+    { label: "Claude", phrase: "hey claude", command: "claude-vscode.focus" },
+    {
+      label: "Copilot",
+      phrase: ["hey copilot", "Open Copilot"],
+      command: "workbench.action.chat.open",
+    },
+    { label: "Terminal", phrase: "computer", command: "workbench.action.terminal.focus" },
+  ];
+
+  it("matches a single-phrase route", () => {
+    expect(matchRoute(routes, "hey claude")?.label).toBe("Claude");
+  });
+
+  it("matches case insensitively", () => {
+    expect(matchRoute(routes, "HEY Claude")?.label).toBe("Claude");
+  });
+
+  it("matches an alias inside a phrase array", () => {
+    expect(matchRoute(routes, "open copilot")?.label).toBe("Copilot");
+  });
+
+  it("selects the correct route out of several", () => {
+    expect(matchRoute(routes, "computer")?.label).toBe("Terminal");
+  });
+
+  it("returns undefined when nothing matches", () => {
+    expect(matchRoute(routes, "hey siri")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty routing table", () => {
+    expect(matchRoute([], "hey claude")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty detected phrase", () => {
+    expect(matchRoute(routes, "")).toBeUndefined();
+    expect(matchRoute(routes, "   ")).toBeUndefined();
+  });
+
+  it("requires a whole-phrase match, not a substring", () => {
+    expect(matchRoute(routes, "hey")).toBeUndefined();
+    expect(matchRoute(routes, "hey claude please")).toBeUndefined();
+  });
+});

--- a/tests/unit/routeValidation.test.ts
+++ b/tests/unit/routeValidation.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterValidRoutes,
+  isValidRoute,
+  resolveRoutes,
+} from "../../src/wakeWordCore";
+import { DEFAULT_ROUTES } from "../../src/extension";
+import type { WakePhrase } from "../../src/speechEngineInterface";
+
+const claude: WakePhrase = {
+  label: "Claude",
+  phrase: "hey claude",
+  command: "claude-vscode.focus",
+};
+
+describe("isValidRoute", () => {
+  it("accepts a complete route", () => {
+    expect(isValidRoute(claude)).toBe(true);
+  });
+
+  it("accepts a route with an alias array", () => {
+    expect(isValidRoute({ ...claude, phrase: ["hey claude", "open claude"] })).toBe(true);
+  });
+
+  it("rejects a route with no phrase", () => {
+    expect(isValidRoute({ ...claude, phrase: "" })).toBe(false);
+    expect(isValidRoute({ ...claude, phrase: "   " })).toBe(false);
+    expect(isValidRoute({ ...claude, phrase: [] })).toBe(false);
+    expect(isValidRoute({ ...claude, phrase: ["", "  "] })).toBe(false);
+  });
+
+  it("rejects a route with a missing label", () => {
+    expect(isValidRoute({ ...claude, label: "" })).toBe(false);
+    expect(isValidRoute({ ...claude, label: "  " })).toBe(false);
+  });
+
+  it("rejects a route with a missing command", () => {
+    expect(isValidRoute({ ...claude, command: "" })).toBe(false);
+    expect(isValidRoute({ ...claude, command: "  " })).toBe(false);
+  });
+
+  it("rejects a non-object", () => {
+    expect(isValidRoute(undefined)).toBe(false);
+    expect(isValidRoute(null)).toBe(false);
+  });
+
+  it("accepts a route whose alias array is only partly usable", () => {
+    // The unusable alias is discarded later by normalizePhrases; the route
+    // itself still has something to listen for.
+    expect(isValidRoute({ ...claude, phrase: ["hey claude", ""] })).toBe(true);
+  });
+
+  // Settings JSON is not schema-enforced, so a wrong-typed field reaches here.
+  it("does not throw on wrong-typed fields", () => {
+    const bad = { label: 7, phrase: 42, command: null } as unknown as WakePhrase;
+    expect(() => isValidRoute(bad)).not.toThrow();
+    expect(isValidRoute(bad)).toBe(false);
+  });
+});
+
+describe("filterValidRoutes", () => {
+  it("keeps only usable routes and preserves order", () => {
+    const routes = [
+      { label: "A", phrase: "alpha", command: "cmd.a" },
+      { label: "", phrase: "beta", command: "cmd.b" },
+      { label: "C", phrase: "", command: "cmd.c" },
+      { label: "D", phrase: "delta", command: "" },
+      { label: "E", phrase: "echo", command: "cmd.e" },
+    ];
+    expect(filterValidRoutes(routes).map((r) => r.label)).toEqual(["A", "E"]);
+  });
+
+  it("returns an empty array for an empty input", () => {
+    expect(filterValidRoutes([])).toEqual([]);
+  });
+
+  it("returns an empty array for a non-array input", () => {
+    expect(filterValidRoutes(undefined as unknown as WakePhrase[])).toEqual([]);
+  });
+});
+
+describe("resolveRoutes", () => {
+  it("uses the user routes when at least one is valid", () => {
+    const user = [
+      { label: "", phrase: "beta", command: "cmd.b" },
+      { label: "E", phrase: "echo", command: "cmd.e" },
+    ];
+    expect(resolveRoutes(user, DEFAULT_ROUTES).map((r) => r.label)).toEqual(["E"]);
+  });
+
+  it("falls back to the defaults when there are no user routes", () => {
+    expect(resolveRoutes([], DEFAULT_ROUTES)).toEqual(DEFAULT_ROUTES);
+  });
+
+  it("falls back to the defaults when every user route is unusable", () => {
+    const user = [
+      { label: "", phrase: "", command: "" },
+      { label: "X", phrase: "  ", command: "cmd.x" },
+    ];
+    expect(resolveRoutes(user, DEFAULT_ROUTES)).toEqual(DEFAULT_ROUTES);
+  });
+
+  it("returns a copy of the defaults so callers cannot mutate them", () => {
+    const resolved = resolveRoutes([], DEFAULT_ROUTES);
+    expect(resolved).not.toBe(DEFAULT_ROUTES);
+    resolved.pop();
+    expect(DEFAULT_ROUTES).toHaveLength(3);
+  });
+});
+
+describe("DEFAULT_ROUTES", () => {
+  it("ships only usable routes", () => {
+    expect(DEFAULT_ROUTES.length).toBeGreaterThan(0);
+    for (const route of DEFAULT_ROUTES) {
+      expect(isValidRoute(route)).toBe(true);
+    }
+  });
+
+  it("has no duplicate phrases across routes", () => {
+    const seen = new Set<string>();
+    for (const route of DEFAULT_ROUTES) {
+      const phrases = Array.isArray(route.phrase) ? route.phrase : [route.phrase];
+      for (const p of phrases) {
+        const key = p.toLowerCase().trim();
+        expect(seen.has(key)).toBe(false);
+        seen.add(key);
+      }
+    }
+  });
+});

--- a/tests/unit/stdoutProtocol.test.ts
+++ b/tests/unit/stdoutProtocol.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from "vitest";
+import { parseEngineLine, splitLines } from "../../src/wakeWordCore";
+
+describe("parseEngineLine", () => {
+  it("parses READY", () => {
+    expect(parseEngineLine("READY")).toEqual({ type: "ready" });
+  });
+
+  it("parses DETECTED with a confidence", () => {
+    expect(parseEngineLine("DETECTED:hey claude|0.92")).toEqual({
+      type: "detected",
+      phrase: "hey claude",
+      confidence: 0.92,
+    });
+  });
+
+  it("lowercases and trims the detected phrase", () => {
+    expect(parseEngineLine("DETECTED:  Hey CLAUDE  |0.5")).toMatchObject({
+      phrase: "hey claude",
+    });
+  });
+
+  it("falls back to the default confidence when there is no separator", () => {
+    expect(parseEngineLine("DETECTED:hey claude")).toEqual({
+      type: "detected",
+      phrase: "hey claude",
+      confidence: 1.0,
+    });
+  });
+
+  it("falls back to the default confidence when the score is not a number", () => {
+    expect(parseEngineLine("DETECTED:hey claude|notanumber")).toEqual({
+      type: "detected",
+      phrase: "hey claude",
+      confidence: 1.0,
+    });
+  });
+
+  it("honours a caller-supplied default confidence", () => {
+    // The Windows engine passes 0 so a malformed line can never clear the
+    // configured threshold.
+    expect(parseEngineLine("DETECTED:hey claude", 0)).toMatchObject({ confidence: 0 });
+    expect(parseEngineLine("DETECTED:hey claude|", 0)).toMatchObject({ confidence: 0 });
+    expect(parseEngineLine("DETECTED:hey claude|oops", 0)).toMatchObject({ confidence: 0 });
+  });
+
+  it("accepts an empty phrase", () => {
+    expect(parseEngineLine("DETECTED:|0.5")).toEqual({
+      type: "detected",
+      phrase: "",
+      confidence: 0.5,
+    });
+  });
+
+  it("treats the last pipe as the separator", () => {
+    expect(parseEngineLine("DETECTED:a|b|c|0.75")).toEqual({
+      type: "detected",
+      phrase: "a|b|c",
+      confidence: 0.75,
+    });
+  });
+
+  it("parses ERROR", () => {
+    expect(parseEngineLine("ERROR:something broke")).toEqual({
+      type: "error",
+      message: "something broke",
+    });
+  });
+
+  it("parses DEBUG", () => {
+    expect(parseEngineLine("DEBUG:some info")).toEqual({
+      type: "debug",
+      message: "some info",
+    });
+  });
+
+  it("preserves colons inside an error message", () => {
+    expect(parseEngineLine("ERROR:Failed to open microphone: access denied")).toEqual({
+      type: "error",
+      message: "Failed to open microphone: access denied",
+    });
+  });
+
+  it("tolerates surrounding whitespace and carriage returns", () => {
+    expect(parseEngineLine("  READY\r")).toEqual({ type: "ready" });
+    expect(parseEngineLine("\tDETECTED:hey claude|0.4 ")).toMatchObject({
+      phrase: "hey claude",
+      confidence: 0.4,
+    });
+  });
+
+  it("returns null for a blank line", () => {
+    expect(parseEngineLine("")).toBeNull();
+    expect(parseEngineLine("   ")).toBeNull();
+  });
+
+  it("returns null for unrecognised output", () => {
+    // Dependencies of the child sometimes write to stdout. That must not be
+    // mistaken for a protocol verb.
+    expect(parseEngineLine("some random text")).toBeNull();
+    expect(parseEngineLine("Warning: onnxruntime loaded")).toBeNull();
+    expect(parseEngineLine("readyish")).toBeNull();
+    expect(parseEngineLine("ready")).toBeNull();
+  });
+
+  it("does not treat a bare verb without its colon as a message", () => {
+    expect(parseEngineLine("DEBUG")).toBeNull();
+    expect(parseEngineLine("ERROR")).toBeNull();
+    expect(parseEngineLine("DETECTED")).toBeNull();
+  });
+});
+
+describe("splitLines", () => {
+  it("returns complete lines and keeps the trailing partial", () => {
+    expect(splitLines("READY\nDEBUG:a\nDETEC")).toEqual({
+      lines: ["READY", "DEBUG:a"],
+      rest: "DETEC",
+    });
+  });
+
+  it("keeps everything as the remainder when there is no newline", () => {
+    expect(splitLines("READ")).toEqual({ lines: [], rest: "READ" });
+  });
+
+  it("leaves an empty remainder when the chunk ends on a newline", () => {
+    expect(splitLines("READY\n")).toEqual({ lines: ["READY"], rest: "" });
+  });
+
+  it("reassembles a verb split across two chunks", () => {
+    const first = splitLines("DETECTED:hey cl");
+    const second = splitLines(first.rest + "aude|0.9\n");
+    expect(second.lines).toEqual(["DETECTED:hey claude|0.9"]);
+    expect(parseEngineLine(second.lines[0])).toMatchObject({ phrase: "hey claude" });
+  });
+
+  it("handles an empty buffer", () => {
+    expect(splitLines("")).toEqual({ lines: [], rest: "" });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,6 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true
   },
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,0 +1,28 @@
+import { fileURLToPath } from "url";
+import { defineConfig } from "vitest/config";
+
+/**
+ * Unit tests only: no microphone, no child processes, no network, no VS Code.
+ *
+ * `vscode` is not a real npm package, it is injected by the extension host at
+ * runtime, so any src module that imports it is unresolvable under a plain
+ * Node test runner. The alias below points those imports at a hand-written
+ * stub that satisfies the surface the tested code touches.
+ *
+ * The file is .mts, not .ts, because the package is CommonJS and Vite's native
+ * config loader will not accept ESM syntax from a .ts file in a CJS package.
+ */
+export default defineConfig({
+  resolve: {
+    alias: {
+      vscode: fileURLToPath(new URL("./tests/mocks/vscode.ts", import.meta.url)),
+    },
+  },
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts", "tests/**/*.test.js"],
+    coverage: {
+      include: ["src/**/*.ts", "engine/lib/**/*.js"],
+    },
+  },
+});


### PR DESCRIPTION
Upgrade engine mic capture from decibri 1.0.0 to 5.7.0. Enable Silero VAD so audio is only processed during speech, reducing idle CPU. Add highpass (80 Hz), AGC (-18 dB), and DC removal conditioning to improve detection reliability. Pre-roll ring buffer holds onset audio that arrives before the VAD scores it.

Fix sherpa engine on Windows: sherpa-onnx WASM build treats backslash paths as relative, so the KWS model never loaded. Paths normalised to forward slashes.

Fix stop() in both engines to cancel pending retry timers before the early-return guard. Previously, disabling listening during crash backoff could silently reopen the microphone.

Add 177 automated tests across 12 files covering phrase normalisation, stdout protocol parsing, path normalisation, debounce, route validation, engine selection, pre-roll ring buffer, config parsing, BPE tokenisation, and error mapping. Extract shared logic into wakeWordCore.ts and engine/lib/ so tests run against the shipped code.

Fix non-string phrase crashing activation. Fix stdin drain dropping commands after the first line in a chunk. Fix modelPath producing platform-dependent output.

Clear all npm audit vulnerabilities. Bump @vscode/vsce 2.x to 3.x and ovsx 0.8.x to 1.x. Pin @types/vscode to ~1.85.0 to match engines.vscode.

Expand CI to 3-leg matrix (Windows, macOS, Linux) with fail-fast: false. Add Dependabot coverage for engine/ dependencies. Remove docs/ and .claude/ from published .vsix.