### PR TITLE
feat: acknowledged mic release, model verification, CI smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
             target: darwin-arm64
           - os: ubuntu-latest
             target: linux-x64
+          # GitHub's public ARM runner label is ubuntu-24.04-arm, not a
+          # variant of ubuntu-latest, which is x64.
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
 
     runs-on: ${{ matrix.os }}
 
@@ -45,3 +49,14 @@ jobs:
       # broken engine dependency has shipped a dead release before (v0.5.0).
       - name: Install engine dependencies
         run: cd engine && npm install
+
+      # Loads decibri, sherpa-onnx, and sentencepiece-js on this platform and
+      # exits. Catches MODULE_NOT_FOUND and native ABI mismatches, neither of
+      # which the source tree shows: v0.4.0 shipped exactly that failure.
+      - name: Smoke test engine
+        run: node engine/audio-engine.js --self-test
+
+      # Packaging is what actually broke twice. Building the artifact on the
+      # pull request catches a vsce failure before it reaches a release.
+      - name: Package VSIX
+        run: npx vsce package --target ${{ matrix.target }} -o wake-word-${{ matrix.target }}-ci.vsix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,11 @@ jobs:
           - os: ubuntu-latest
             target: linux-x64
             lint: false
+          # GitHub's public ARM runner label is ubuntu-24.04-arm, not a
+          # variant of ubuntu-latest, which is x64.
+          - os: ubuntu-24.04-arm
+            target: linux-arm64
+            lint: false
 
     runs-on: ${{ matrix.os }}
 
@@ -33,6 +38,11 @@ jobs:
 
       - name: Install engine dependencies
         run: cd engine && npm install
+
+      # Fail the release before publishing if the shipped engine tree cannot
+      # load on this platform.
+      - name: Smoke test engine
+        run: node engine/audio-engine.js --self-test
 
       - name: Lint and compile
         if: matrix.lint

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,13 @@ npm run lint               # Run ESLint + SVG check on README.md. Do not use --f
 npm test                   # Run the unit test suite once (vitest)
 npm run test:watch         # Run the unit tests in watch mode
 npm run package            # Build .vsix package
+
+node engine/audio-engine.js --self-test   # Load the engine dependency tree and exit
 ```
+
+`--self-test` requires `engine/node_modules` (`cd engine && npm install`). It
+opens no microphone and needs no model, so it is safe to run anywhere. CI runs
+it on all four platforms.
 
 Run `npm run lint`, `npm run compile`, and `npm test` before committing. All
 three must pass cleanly.
@@ -28,7 +34,7 @@ wake-word/
     sherpaEngine.ts           # SherpaEngine: audio-engine.js child process under system Node.js
   engine/
     audio-engine.js           # Child process: decibri VAD-gated mic capture + sherpa-onnx keyword spotting
-    package.json              # Engine dependencies (decibri 5.7.0, sherpa-onnx 1.12.28, sentencepiece-js 1.1.0)
+    package.json              # Engine dependencies (decibri 5.7.0, sherpa-onnx 1.13.6, sentencepiece-js 1.1.0)
   engine/lib/          # Pure engine logic, unit tested without a microphone
     model-path.js      # Forward-slash model paths for the sherpa-onnx WASM VFS
     vad-gate.js        # Pre-roll ring buffer and VAD gate state machine
@@ -45,7 +51,7 @@ wake-word/
   .github/
     dependabot.yml     # Dependency updates for both / and /engine
     workflows/
-      ci.yml           # CI: lint, compile, install engine deps on push and PR
+      ci.yml           # CI: lint, compile, test, engine deps, engine self-test, .vsix package
       release.yml      # CI: build .vsix, publish to Marketplace and Open VSX
 ```
 
@@ -55,7 +61,9 @@ wake-word/
 
 ## Architecture
 
-The extension selects a speech engine via `createEngine()` and wires it with `wireEngine()`. Both engines communicate via stdout using four protocols: `READY`, `DETECTED:<phrase>|<confidence>`, `ERROR:<message>`, and `DEBUG:<info>`. The extension reads stdout, matches phrases, and fires VS Code commands. All events are logged to a dedicated "Wake Word" output channel.
+The extension selects a speech engine via `createEngine()` and wires it with `wireEngine()`. Both engines communicate via stdout: `READY`, `DETECTED:<phrase>|<confidence>` (the confidence suffix is optional), `RELEASED`, `ERROR:<message>`, and `DEBUG:<info>`. The extension reads stdout, matches phrases, and fires VS Code commands. All events are logged to a dedicated "Wake Word" output channel.
+
+Only the Windows engine produces a real confidence score. sherpa-onnx's keyword spotter applies its own threshold and returns nothing usable, so `audio-engine.js` sends `DETECTED:<phrase>` with no suffix and `SherpaEngine` emits the detection with no confidence. Do not reintroduce a placeholder score: a fixed `confidence: 1.00` in the log made the two engines look comparable when they are not.
 
 **WindowsSpeechEngine** spawns a PowerShell process using `System.Speech.Recognition` with a synchronous `Recognize()` polling loop. No model downloads; the engine ships with Windows.
 
@@ -63,7 +71,11 @@ The extension selects a speech engine via `createEngine()` and wires it with `wi
 
 `decibri` runs with Silero VAD enabled and `audio-engine.js` only feeds audio to the keyword spotter while speech is present, so an idle editor does not run the transducer. decibri emits `'data'` for a chunk *before* it scores that chunk, so the handler holds chunks in a 500 ms pre-roll ring and flushes them when `'speech'` fires; drop the pre-roll and the onset of the wake phrase never reaches the spotter. The `'data'` listener is also what keeps the capture stream pumping, so it must stay unconditional. Capture is conditioned with `dcRemoval`, an 80 Hz `highpass`, and `agc: -18`.
 
-On wake word detection, the engine process is killed to release the microphone (handoff), then respawned after a cooldown. This ensures only one thing uses the mic at a time.
+On wake word detection the microphone is released and the engine process torn down (handoff), then respawned after a cooldown, so only one thing uses the mic at a time. The release is acknowledged, not assumed: `audio-engine.js` sends `RELEASED` once `mic.stop()` has returned and `SherpaEngine.releaseThenKill()` waits for that line before force-killing, capped at 500 ms. `forceKill()` is the unacknowledged path, used by `start()` and `stop()`. The Windows engine has no `RELEASED`, and needs none: System.Speech holds the capture device for the lifetime of the PowerShell process, so process exit is the confirmation.
+
+`pause()` stays synchronous and the target command still fires as soon as it returns; the release completes underneath within the timeout. Ordering the command strictly after `RELEASED` is a handoff policy change and should be designed separately.
+
+The model download verifies the tarball against the pinned `MODEL_SHA256` in `sherpaEngine.ts` before extraction, and follows at most `MAX_REDIRECTS` (5) hops. Changing `MODEL_URL` or `MODEL_VERSION` means recomputing that digest; the command to do so is in the constant's comment.
 
 **IMPORTANT**: The PowerShell process must use Windows PowerShell (`System32\WindowsPowerShell\v1.0\powershell.exe`), not PowerShell Core (`pwsh`). `System.Speech` is not available in PowerShell Core.
 
@@ -129,6 +141,10 @@ Manual testing checklist:
 **NEVER** use PowerShell double-quoted strings for user-provided content (injection risk).
 
 **NEVER** add `darwin-x64` as a CI build target. Intel Mac (pre-2020) is excluded: the `macos-13` GitHub Actions runner has uncertain long-term availability, and `decibri` darwin-x64 pre-built binaries are unconfirmed. Revisit only if a darwin-x64 user files an issue with confirmed binary support.
+
+CI and release build four targets: `win32-x64`, `darwin-arm64`, `linux-x64`, and `linux-arm64`. Linux ARM64 runs on the `ubuntu-24.04-arm` runner label, not a variant of `ubuntu-latest`, which is x64; `decibri` ships a `linux-arm64-gnu` pre-built binary.
+
+**NEVER** ship a model download without a verified digest. The tarball is fetched over redirects to a CDN and loaded straight into the keyword spotter.
 
 **NEVER** modify the ATTRIBUTION.md protocol frontmatter without explicit instruction.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no child process, no network, and no VS Code API, and runs on all
   three platforms in CI.
 
+- `audio-engine.js --self-test` loads decibri, sherpa-onnx, and
+  sentencepiece-js and exits without opening the microphone. CI runs it
+  on every platform, so a missing module or a native ABI mismatch in the
+  shipped engine tree fails the build instead of the user's install.
+
 ### Changed
 
 - Extracted the logic shared by the extension host and both engines into
@@ -50,6 +55,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   three platforms (Windows, macOS, Linux) instead of Ubuntu only. The
   matrix mirrors release.yml so a platform-specific break surfaces on
   the pull request rather than at publish time.
+- The default terminal wake phrase is now "Hey Computer" rather than
+  "Computer". A single common English word is spoken far too often in
+  ordinary conversation to sit behind an always-listening microphone.
+  Customised routes in `settings.json` are unaffected; the defaults only
+  apply when `wakeWord.routes` is empty.
+- The sherpa engine no longer reports a confidence for its detections.
+  Its keyword spotter applies its own threshold and returns no usable
+  score, so every detection was logged as "confidence: 1.00", which made
+  the two engines' logs look comparable when they never were. Windows
+  Speech detections continue to show their real scores.
+- CI and release now build for Linux ARM64 as well, bringing both
+  matrices to four targets: win32-x64, darwin-arm64, linux-x64, and
+  linux-arm64. decibri already ships a linux-arm64 pre-built binary.
+- CI now packages the `.vsix` on every platform. The source tree passing
+  is not evidence the artifact builds: packaging has failed twice, once
+  reaching users as a dead v0.4.0 release.
 
 ### Fixed
 
@@ -73,6 +94,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.vscodeignore`.
 - Fixed `package-lock.json` version drift; the lockfile root version was
   never regenerated for the 0.5.1 bump.
+- Microphone release is now acknowledged rather than assumed. The audio
+  engine sends `RELEASED` once `mic.stop()` has returned, and the
+  extension waits for that line before force-killing the child, up to
+  500 ms. Previously the process was killed and the capture device was
+  assumed torn down by the time the target assistant asked for it, which
+  was only ever usually true. On Windows there is no `RELEASED`:
+  System.Speech holds the device for the lifetime of the PowerShell
+  process, so process exit is the confirmation and it is now logged.
+- A write to an audio engine child that had already exited could take
+  the extension host down. EPIPE arrives as an `error` event on the
+  stream rather than a thrown exception, so the existing `try`/`catch`
+  around each write never covered it and nothing listened for it.
 
 ### Security
 
@@ -86,6 +119,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vulnerabilities. These are build and publish tooling only and never
   shipped to users, but they run with `VSCE_PAT` and `OVSX_PAT` in
   scope during a release.
+- The downloaded speech model is now verified against a pinned SHA-256
+  digest before extraction, and a rejected tarball is deleted rather
+  than left on disk. The download follows HTTP redirects to a CDN host
+  and its contents are loaded straight into the keyword spotter, so
+  nothing previously stood between a hijacked redirect and a model of
+  someone else's choosing running on the user's machine.
+- The model download now follows at most 5 redirect hops. A redirect
+  loop previously recursed until the extension host ran out of stack.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@
 
 Say a wake phrase and the right AI assistant opens -- no clicking required.
 
-Say **"Hey Claude"** and Claude opens. Say **"Hey Copilot"** and Copilot opens. Say **"Computer"** and the terminal focuses. The extension handles the routing, pauses its own mic so the assistant can use it, then resumes listening when the voice session ends.
+Say **"Hey Claude"** and Claude opens. Say **"Hey Copilot"** and Copilot opens. Say **"Hey Computer"** and the terminal focuses. The extension handles the routing, pauses its own mic so the assistant can use it, then resumes listening when the voice session ends.
 
 **Zero config. No API keys. No accounts. No system dependencies.** Install and go.
 
@@ -145,7 +145,7 @@ These work out of the box with no configuration:
 | --- | --- | --- |
 | "Hey Copilot" | GitHub Copilot Chat | `workbench.action.chat.open` |
 | "Hey Claude" | Claude Code | `claude-vscode.focus` |
-| "Computer" | Terminal | `workbench.action.terminal.focus` |
+| "Hey Computer" | Terminal | `workbench.action.terminal.focus` |
 
 ### Custom routes
 
@@ -199,7 +199,7 @@ Override the global cooldown for individual routes with `cooldownSeconds`:
 ```json
 {
   "label": "Terminal",
-  "phrase": "computer",
+  "phrase": "hey computer",
   "command": "workbench.action.terminal.focus",
   "cooldownSeconds": 10
 }
@@ -209,7 +209,8 @@ Override the global cooldown for individual routes with `cooldownSeconds`:
 
 When a wake phrase is detected:
 
-1. The extension **immediately kills** the speech engine process, releasing the mic
+1. The extension asks the speech engine to close the microphone and waits for it to
+   confirm, then kills the process (forcing it after 500 ms if no confirmation arrives)
 2. The target VS Code command fires (opening the assistant)
 3. The assistant's voice mode takes over the microphone with no contention
 4. After `wakeWord.cooldownSeconds` (default: 30), wake word listening resumes

--- a/engine/audio-engine.js
+++ b/engine/audio-engine.js
@@ -12,9 +12,14 @@
  *
  * Protocol (stdout):
  *   READY                        — KWS loaded, mic open, listening
- *   DETECTED:<phrase>|<conf>     — keyword detected (phrase lowercase, conf 0–1)
+ *   DETECTED:<phrase>             — keyword detected (phrase lowercase)
+ *   RELEASED                     — microphone closed, safe to take the device
  *   ERROR:<msg>                  — fatal error
  *   DEBUG:<msg>                  — diagnostic info
+ *
+ * The keyword spotter applies its own threshold and returns no usable score,
+ * so DETECTED carries no confidence value. The parser still accepts the
+ * `|<conf>` suffix the Windows engine sends.
  *
  * Config: read from stdin as a single JSON line then stdin is closed.
  *   { phrases: [{phrase: string, label: string}],
@@ -23,6 +28,9 @@
  *     debugMode: boolean }
  *
  * Stop: close stdin or send "stop\n" on stdin.
+ *
+ * Self-test: `node audio-engine.js --self-test` loads every dependency and
+ * exits without opening the microphone. CI runs it on each platform.
  */
 
 // Resolve modules relative to this script's own node_modules,
@@ -73,6 +81,67 @@ function debug(msg) {
 function fatal(msg) {
   out('ERROR:' + msg);
   process.exit(1);
+}
+
+/**
+ * Exit once stdout has actually flushed.
+ *
+ * process.stdout is an asynchronous pipe on POSIX, so process.exit() straight
+ * after a write can truncate it. Both RELEASED and the self-test result are
+ * read by something on the other end of that pipe, so neither may be lost.
+ * The timer is the backstop for a pipe that never drains.
+ */
+function exitWhenFlushed(code) {
+  let exited = false;
+  const finish = () => {
+    if (exited) return;
+    exited = true;
+    process.exit(code);
+  };
+  try {
+    process.stdout.write('', finish);
+  } catch {
+    finish();
+    return;
+  }
+  setTimeout(finish, 2000);
+}
+
+/**
+ * Load every dependency the engine needs and report what resolved.
+ *
+ * The extension ships engine/node_modules to users, and a break there does not
+ * show up in the source tree: v0.4.0 shipped a MODULE_NOT_FOUND and v0.5.0 a
+ * dead engine dependency. CI runs this on every platform so a missing module
+ * or a native ABI mismatch fails the build instead of the install.
+ */
+function runSelfTest() {
+  try {
+    const { Microphone } = require('decibri');
+    const sherpa = require('sherpa-onnx');
+    const { SentencePieceProcessor } = require('sentencepiece-js');
+
+    if (typeof Microphone !== 'function') {
+      throw new Error('decibri did not export a Microphone constructor');
+    }
+    if (typeof sherpa.createKws !== 'function') {
+      throw new Error('sherpa-onnx did not export createKws');
+    }
+    if (typeof SentencePieceProcessor !== 'function') {
+      throw new Error('sentencepiece-js did not export a SentencePieceProcessor constructor');
+    }
+
+    out('SELF-TEST:OK');
+    out('SELF-TEST:platform=' + process.platform + '-' + process.arch);
+    out('SELF-TEST:node=' + process.versions.node + ' abi=' + process.versions.modules);
+    out('SELF-TEST:decibri=loaded');
+    out('SELF-TEST:sherpa-onnx=loaded');
+    out('SELF-TEST:sentencepiece-js=loaded');
+    exitWhenFlushed(0);
+  } catch (err) {
+    out('SELF-TEST:FAIL:' + err.message);
+    exitWhenFlushed(1);
+  }
 }
 
 async function main(config) {
@@ -194,7 +263,11 @@ async function main(config) {
         const phrase = phraseMap[decodedKey];
         if (phrase) {
           if (debugMode) debug('KWS result: ' + JSON.stringify(result));
-          out('DETECTED:' + phrase + '|1.0');
+          // No confidence suffix: the spotter has already applied the
+          // threshold and the score it returns is not a usable confidence.
+          // Reporting a fixed 1.0 made these lines look comparable to the
+          // Windows engine's real scores when they never were.
+          out('DETECTED:' + phrase);
         } else {
           if (debugMode) debug('Unmatched KWS result: ' + JSON.stringify(result));
         }
@@ -253,6 +326,13 @@ function shutdown() {
     try { mic.stop(); } catch { /* ignore */ }
     mic = null;
   }
+
+  // The capture device is closed. Say so before doing anything else: the
+  // extension waits for RELEASED before firing the command that takes the
+  // microphone over, rather than killing this process and trusting the OS to
+  // have reclaimed the device by then.
+  out('RELEASED');
+
   if (kwsStream) {
     try { kwsStream.free(); } catch { /* ignore */ }
     kwsStream = null;
@@ -261,7 +341,15 @@ function shutdown() {
     try { kws.free(); } catch { /* ignore */ }
     kws = null;
   }
-  process.exit(0);
+  exitWhenFlushed(0);
+}
+
+// --self-test loads the dependency tree and exits. It must run before the
+// stdin wiring below, which would otherwise hold the process open waiting for
+// a config line that CI never sends.
+if (process.argv.includes('--self-test')) {
+  runSelfTest();
+  return;
 }
 
 // Read config from stdin (single JSON line)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wake-word",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wake-word",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^20.11.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for your editor with customizable wake word. Fully local, zero config.",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",
@@ -59,7 +59,7 @@
         "wakeWord.routes": {
           "type": "array",
           "default": [],
-          "description": "Wake phrase routing table. Each entry maps a spoken phrase to an editor command. If empty, default routes are used (Hey Copilot, Hey Claude, Computer).",
+          "description": "Wake phrase routing table. Each entry maps a spoken phrase to an editor command. If empty, default routes are used (Hey Copilot, Hey Claude, Hey Computer).",
           "items": {
             "type": "object",
             "required": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,6 +6,7 @@ import { SherpaEngine } from "./sherpaEngine";
 import {
   DETECTION_DEBOUNCE_MS,
   clampThreshold,
+  formatConfidence,
   resolveRoutes,
   selectEngineKind,
   shouldDebounce,
@@ -37,7 +38,9 @@ export const DEFAULT_ROUTES: WakePhrase[] = [
   },
   {
     label: "Terminal",
-    phrase: "computer",
+    // "Hey Computer", not "Computer": a single common English word triggers
+    // on ordinary speech far too readily for an always-listening extension.
+    phrase: "hey computer",
     command: "workbench.action.terminal.focus",
   },
 ];
@@ -58,7 +61,7 @@ function createEngine(context: vscode.ExtensionContext): ISpeechEngine {
 // ── Engine wiring ────────────────────────────────────────────
 
 function wireEngine(engine: ISpeechEngine): void {
-  engine.on("detected", (phrase: WakePhrase, confidence: number) => {
+  engine.on("detected", (phrase: WakePhrase, confidence?: number) => {
     onWakeWordDetected(phrase, confidence);
   });
   engine.on("started", () => setStatusBar("listening"));
@@ -301,7 +304,7 @@ function buildRoutes(config: vscode.WorkspaceConfiguration): WakePhrase[] {
 
 // ── Wake word triggered ─────────────────────────────────────
 
-async function onWakeWordDetected(phrase: WakePhrase, confidence: number) {
+async function onWakeWordDetected(phrase: WakePhrase, confidence?: number) {
   const now = Date.now();
   if (shouldDebounce(now, lastDetectionTime, DETECTION_DEBOUNCE_MS)) {
     log("info", `Debounced duplicate detection: ${phrase.label}`);
@@ -309,7 +312,9 @@ async function onWakeWordDetected(phrase: WakePhrase, confidence: number) {
   }
   lastDetectionTime = now;
 
-  log("info", `Detected: "${phrase.label}" (confidence: ${confidence.toFixed(2)})`);
+  // Only the Windows engine supplies a score; formatConfidence renders
+  // nothing when there is none to show.
+  log("info", `Detected: "${phrase.label}"${formatConfidence(confidence)}`);
 
   const config = vscode.workspace.getConfiguration("wakeWord");
   const showNotification = config.get<boolean>(

--- a/src/sherpaEngine.ts
+++ b/src/sherpaEngine.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "events";
 import { spawn, ChildProcess, execSync } from "child_process";
+import { createHash } from "crypto";
 import { existsSync, mkdirSync, createWriteStream, writeFileSync, readFileSync, unlinkSync } from "fs";
 import * as path from "path";
 import * as https from "https";
@@ -32,8 +33,17 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
   private currentDebugMode = false;
   private retryCount = 0;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private releaseTimer: ReturnType<typeof setTimeout> | null = null;
   private static readonly MAX_RETRIES = 3;
   private static readonly RETRY_DELAYS = [2000, 5000, 10000];
+  /**
+   * How long to wait for the child's RELEASED before force killing it.
+   *
+   * mic.stop() is a device close, not a network call: half a second is
+   * generous. The cap exists so a wedged child cannot hold the microphone
+   * open, not because the acknowledgement is expected to be slow.
+   */
+  private static readonly RELEASE_TIMEOUT_MS = 500;
 
   constructor(
     private readonly context: vscode.ExtensionContext,
@@ -55,7 +65,7 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
       return;
     }
 
-    this.killProcess();
+    this.forceKill();
 
     this._killedIntentionally = false;
     this.currentPhrases = phrases;
@@ -81,6 +91,15 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
       stdio: ["pipe", "pipe", "pipe"],
     });
 
+    // A write to a child that has already exited surfaces EPIPE as an 'error'
+    // event on the stream, not as a thrown exception, so the try/catch around
+    // each write does not cover it. Without a listener that event takes the
+    // extension host down, and the release path deliberately writes to a child
+    // that is on its way out.
+    this.process.stdin?.on("error", () => {
+      /* child is gone; nothing left to say to it */
+    });
+
     // Send config as JSON line then leave stdin open (child reads more commands)
     const config = {
       phrases: phrases.map((p) => ({
@@ -101,9 +120,7 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
       stdoutBuffer = split.rest;
 
       for (const line of split.lines) {
-        // audio-engine.js always reports 1.0: the keyword spotter has already
-        // applied the threshold, so a missing score means "accepted".
-        const event = parseEngineLine(line, 1.0);
+        const event = parseEngineLine(line);
         if (!event) {
           continue;
         }
@@ -117,12 +134,17 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
           this.emit("debug", event.message);
         } else if (event.type === "error") {
           this.emit("error", new Error(event.message));
-        } else {
+        } else if (event.type === "detected") {
           const match = matchRoute(phrases, event.phrase);
           if (match) {
-            this.emit("detected", match, event.confidence);
+            // No confidence: the keyword spotter applied its own threshold
+            // and returns no usable score. Reporting one anyway put a
+            // meaningless "confidence: 1.00" in every log line.
+            this.emit("detected", match, undefined);
           }
         }
+        // RELEASED is only of interest while a release is in flight, and
+        // releaseThenKill() installs its own listener for it.
       }
     });
 
@@ -206,7 +228,7 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
     }
 
     this._isPaused = false;
-    this.killProcess();
+    this.forceKill();
     this._isListening = false;
     this.emit("stopped");
   }
@@ -218,7 +240,7 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
 
     this._isPaused = true;
     this.clearRetryTimer();
-    this.killProcess();
+    this.releaseThenKill();
     this._isListening = false;
     this.emit("paused");
   }
@@ -234,6 +256,7 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
 
   dispose(): void {
     this.clearRetryTimer();
+    this.clearReleaseTimer();
     this.stop();
     this.removeAllListeners();
   }
@@ -245,24 +268,120 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
     }
   }
 
-  private killProcess(): void {
-    if (this.process) {
-      this._killedIntentionally = true;
-      this.process.stdout?.removeAllListeners();
-      this.process.stderr?.removeAllListeners();
-      // Send stop command before killing so the mic is released cleanly
-      try {
-        this.process.stdin?.write("stop\n");
-        this.process.stdin?.end();
-      } catch {
-        // Process may have already exited
+  private clearReleaseTimer(): void {
+    if (this.releaseTimer) {
+      clearTimeout(this.releaseTimer);
+      this.releaseTimer = null;
+    }
+  }
+
+  /**
+   * Ask the child to close the microphone and wait until it says it has.
+   *
+   * The extension fires the target command immediately after pause() returns,
+   * and that command exists to hand the microphone to something else. The
+   * previous behaviour killed the child and assumed the OS had torn the
+   * capture device down by the time anything else asked for it, which was
+   * only ever usually true. The child now prints RELEASED once mic.stop() has
+   * returned, so wait for that line and force kill on a timeout so a wedged
+   * child cannot hold the device open indefinitely.
+   *
+   * pause() stays synchronous: the command fires as soon as it returns and
+   * the release completes within the timeout underneath. Ordering the command
+   * strictly after RELEASED is a handoff policy change, not this one.
+   */
+  private releaseThenKill(): void {
+    const proc = this.process;
+    if (!proc) {
+      return;
+    }
+
+    this._killedIntentionally = true;
+    this.clearReleaseTimer();
+
+    // Take stdout over for the duration: the normal handler must not emit a
+    // detection from a process that is already shutting down.
+    proc.stdout?.removeAllListeners("data");
+    proc.stderr?.removeAllListeners("data");
+
+    let settled = false;
+    const finish = (reason: string): void => {
+      if (settled) {
+        return;
       }
-      this.process.removeAllListeners();
-      try {
-        this.process.kill();
-      } catch {
-        // Process may have already exited
+      settled = true;
+      this.clearReleaseTimer();
+      this.emit("debug", `Mic release: ${reason}`);
+      this.forceKill(proc);
+    };
+
+    proc.stdout?.on("data", (data: Buffer) => {
+      for (const line of data.toString().split("\n")) {
+        if (parseEngineLine(line)?.type === "released") {
+          finish("acknowledged by engine");
+          return;
+        }
       }
+    });
+
+    this.releaseTimer = setTimeout(
+      () => finish(`no acknowledgement after ${SherpaEngine.RELEASE_TIMEOUT_MS}ms, forcing`),
+      SherpaEngine.RELEASE_TIMEOUT_MS
+    );
+
+    if (!this.writeStop(proc)) {
+      finish("stdin already closed");
+    }
+  }
+
+  /**
+   * Send the stop command. Returns false when the child is already gone.
+   */
+  private writeStop(proc: ChildProcess): boolean {
+    const stdin = proc.stdin;
+    if (!stdin || !stdin.writable || proc.exitCode !== null) {
+      return false;
+    }
+    try {
+      stdin.write("stop\n");
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Tear the child down now, without waiting for an acknowledgement.
+   *
+   * `target` defaults to the current child. releaseThenKill() passes the
+   * process it captured, because the exit handler may already have cleared
+   * `this.process` by the time the acknowledgement or the timeout lands.
+   */
+  private forceKill(target: ChildProcess | null = this.process): void {
+    const proc = target;
+    if (!proc) {
+      return;
+    }
+
+    this._killedIntentionally = true;
+    this.clearReleaseTimer();
+    proc.stdout?.removeAllListeners();
+    proc.stderr?.removeAllListeners();
+    // Ask for a clean release first even here: a child that acts on it closes
+    // the device itself rather than leaving the OS to reclaim it.
+    this.writeStop(proc);
+    try {
+      proc.stdin?.end();
+    } catch {
+      // Process may have already exited
+    }
+    proc.removeAllListeners();
+    try {
+      proc.kill();
+    } catch {
+      // Process may have already exited
+    }
+    if (this.process === proc) {
       this.process = null;
     }
   }
@@ -312,6 +431,30 @@ const MODEL_URL =
   "https://github.com/k2-fsa/sherpa-onnx/releases/download/kws-models/" +
   MODEL_NAME + ".tar.bz2";
 
+/**
+ * SHA-256 of the model tarball at MODEL_URL (17,626,723 bytes).
+ *
+ * The download follows HTTP redirects to a CDN host and the result is fed
+ * straight into the keyword spotter, so nothing but this digest stands
+ * between a hijacked redirect and a model of someone else's choosing loading
+ * on the user's machine. Recompute and update this whenever MODEL_URL or
+ * MODEL_VERSION changes:
+ *
+ *   curl -L -o model.tar.bz2 "<MODEL_URL>"
+ *   shasum -a 256 model.tar.bz2      # certutil -hashfile model.tar.bz2 SHA256
+ */
+export const MODEL_SHA256 =
+  "f170013b4716e41b62b9bfd809687c207cef798ef9bc6534d524e17af9b6561a";
+
+/**
+ * Redirect hops the model download will follow before giving up.
+ *
+ * GitHub answers a release asset with one 302 to a CDN host, so at least one
+ * hop is required. The cap stops a redirect loop from recursing until the
+ * extension host runs out of stack.
+ */
+export const MAX_REDIRECTS = 5;
+
 const MODEL_FILES = [
   "encoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx",
   "decoder-epoch-12-avg-2-chunk-16-left-64.int8.onnx",
@@ -337,6 +480,29 @@ export function shouldFollowRedirect(
     typeof location === "string" &&
     location.length > 0
   );
+}
+
+/** True once the downloader has followed as many redirects as it will. */
+export function redirectLimitExceeded(hops: number, max: number = MAX_REDIRECTS): boolean {
+  return hops >= max;
+}
+
+/**
+ * Throw unless the downloaded tarball matches the expected digest.
+ *
+ * Runs before extraction, so a tampered or truncated download never reaches
+ * `tar` and never reaches the keyword spotter. The message carries a prefix
+ * of each digest: enough to tell a corrupted download from a substituted one
+ * in a bug report, without a wall of hex in a notification.
+ */
+export function verifyModelHash(actual: string, expected: string = MODEL_SHA256): void {
+  if (actual.toLowerCase() !== expected.toLowerCase()) {
+    throw new Error(
+      "Model integrity check failed. Expected SHA-256 " +
+        `${expected.substring(0, 16)}..., got ${actual.substring(0, 16)}...: ` +
+        "the download may be corrupted or tampered with."
+    );
+  }
 }
 
 /**
@@ -396,10 +562,17 @@ async function downloadModel(
       await new Promise<void>((resolve, reject) => {
         const file = createWriteStream(tarballPath);
 
-        function get(url: string): void {
+        function get(url: string, hops = 0): void {
           https.get(url, (res) => {
             if (shouldFollowRedirect(res.statusCode, res.headers.location)) {
-              get(res.headers.location as string);
+              if (redirectLimitExceeded(hops)) {
+                res.resume();
+                reject(
+                  new Error(`Too many redirects (over ${MAX_REDIRECTS}) downloading model`)
+                );
+                return;
+              }
+              get(res.headers.location as string, hops + 1);
               return;
             }
             if (res.statusCode !== 200) {
@@ -424,9 +597,30 @@ async function downloadModel(
         get(MODEL_URL);
       });
 
+      // Verify before extraction. The download followed redirects to a CDN
+      // host and the files inside are loaded straight into the keyword
+      // spotter, so a bad tarball must never reach `tar`.
+      progress.report({ message: "Verifying..." });
+      const actualHash = createHash("sha256").update(readFileSync(tarballPath)).digest("hex");
+      debugLog?.("Model SHA-256: " + actualHash);
+      try {
+        verifyModelHash(actualHash);
+      } catch (err) {
+        // Leaving a rejected tarball on disk would have the next attempt
+        // resume against a file that is already known bad.
+        try {
+          unlinkSync(tarballPath);
+        } catch {
+          // non-fatal
+        }
+        throw err;
+      }
+
       progress.report({ message: "Extracting..." });
       debugLog?.("Extracting " + tarballPath);
 
+      // The tarball's entries are all under a single MODEL_NAME directory, so
+      // this lands on modelDir directly.
       // Use system tar (available on macOS and Linux where SherpaEngine is used)
       execSync(`tar -xjf "${tarballPath}" -C "${storageDir}"`);
 

--- a/src/speechEngineInterface.ts
+++ b/src/speechEngineInterface.ts
@@ -11,7 +11,12 @@ export interface ISpeechEngine {
   pause(): void;
   resume(): void;
   dispose(): void;
-  on(event: "detected", cb: (phrase: WakePhrase, confidence: number) => void): this;
+  /**
+   * `confidence` is absent when the engine has no meaningful score to give.
+   * The sherpa-onnx keyword spotter applies its own threshold and returns
+   * nothing usable, so it omits the value rather than inventing a 1.0.
+   */
+  on(event: "detected", cb: (phrase: WakePhrase, confidence?: number) => void): this;
   on(event: "started" | "stopped" | "paused", cb: () => void): this;
   on(event: "error", cb: (err: Error) => void): this;
   on(event: "warning", cb: (msg: string) => void): this;

--- a/src/wakeWordCore.ts
+++ b/src/wakeWordCore.ts
@@ -143,6 +143,7 @@ export function selectEngineKind(override: string, platform: string): EngineKind
 
 export type EngineEvent =
   | { type: "ready" }
+  | { type: "released" }
   | { type: "detected"; phrase: string; confidence: number }
   | { type: "error"; message: string }
   | { type: "debug"; message: string };
@@ -150,19 +151,25 @@ export type EngineEvent =
 /**
  * Parse one line of an engine's stdout.
  *
- * Both engines emit the same four-verb protocol:
+ * Both engines emit the same protocol:
  *   READY
- *   DETECTED:<phrase>|<confidence>
+ *   DETECTED:<phrase>|<confidence>   (the suffix is optional)
+ *   RELEASED
  *   ERROR:<message>
  *   DEBUG:<message>
+ *
+ * RELEASED is sent by the sherpa engine's child once the microphone has been
+ * closed. The Windows engine has no equivalent: System.Speech holds the
+ * device for the lifetime of the PowerShell process, so process exit is the
+ * release confirmation there.
  *
  * Anything else (blank lines, stray output from a child's dependencies)
  * returns null and is ignored by the caller.
  *
  * `defaultConfidence` is used when a DETECTED line carries no `|<confidence>`
- * suffix or an unparseable one. The sherpa engine's child always reports 1.0,
- * so it passes 1.0; the Windows engine reports a real score and passes 0 so a
- * malformed line can never clear a threshold.
+ * suffix or an unparseable one. The sherpa engine's child sends no suffix at
+ * all and its caller discards the value; the Windows engine reports a real
+ * score and passes 0 so a malformed line can never clear a threshold.
  */
 export function parseEngineLine(
   line: string,
@@ -172,6 +179,9 @@ export function parseEngineLine(
 
   if (trimmed === "READY") {
     return { type: "ready" };
+  }
+  if (trimmed === "RELEASED") {
+    return { type: "released" };
   }
   if (trimmed.startsWith("DEBUG:")) {
     return { type: "debug", message: trimmed.substring(6) };
@@ -194,6 +204,22 @@ export function parseEngineLine(
   }
 
   return null;
+}
+
+/**
+ * Render the confidence suffix for a detection log line.
+ *
+ * Only the Windows engine produces a real score. sherpa-onnx's keyword
+ * spotter applies its own threshold and returns nothing usable, so
+ * SherpaEngine reports no confidence rather than a fabricated 1.0 that made
+ * the two engines' logs look comparable when they are not. An absent or
+ * non-finite value renders as nothing at all.
+ */
+export function formatConfidence(confidence: number | undefined): string {
+  if (typeof confidence !== "number" || !isFinite(confidence)) {
+    return "";
+  }
+  return ` (confidence: ${confidence.toFixed(2)})`;
 }
 
 /**

--- a/src/windowsSpeechEngine.ts
+++ b/src/windowsSpeechEngine.ts
@@ -91,12 +91,14 @@ export class WindowsSpeechEngine extends EventEmitter implements ISpeechEngine {
           this.emit("debug", event.message);
         } else if (event.type === "error") {
           this.emit("error", new Error(event.message));
-        } else {
+        } else if (event.type === "detected") {
           const match = matchRoute(phrases, event.phrase);
           if (match) {
+            // System.Speech returns a real score, so it is reported as given.
             this.emit("detected", match, event.confidence);
           }
         }
+        // This engine never sends RELEASED: process exit is the release.
       }
     });
 
@@ -217,14 +219,26 @@ export class WindowsSpeechEngine extends EventEmitter implements ISpeechEngine {
     }
   }
 
+  /**
+   * Kill the speech process, which is what releases the microphone.
+   *
+   * There is no RELEASED message to wait for here, and none is needed:
+   * System.Speech holds the capture device for the lifetime of the PowerShell
+   * process and Windows reclaims it when that process dies. Exit is the
+   * acknowledgement, so the exit is logged rather than assumed.
+   */
   private killProcess(): void {
     if (this.process) {
+      const proc = this.process;
       this._killedIntentionally = true;
-      this.process.stdout?.removeAllListeners();
-      this.process.stderr?.removeAllListeners();
-      this.process.removeAllListeners();
+      proc.stdout?.removeAllListeners();
+      proc.stderr?.removeAllListeners();
+      proc.removeAllListeners();
+      proc.once("exit", () => {
+        this.emit("debug", "Mic release: speech process exited");
+      });
       try {
-        this.process.kill();
+        proc.kill();
       } catch {
         // Process may have already exited
       }

--- a/tests/unit/modelDownload.test.ts
+++ b/tests/unit/modelDownload.test.ts
@@ -10,7 +10,13 @@ vi.mock("fs", () => ({
   unlinkSync: vi.fn(),
 }));
 
-import { shouldFollowRedirect } from "../../src/sherpaEngine";
+import {
+  MAX_REDIRECTS,
+  MODEL_SHA256,
+  redirectLimitExceeded,
+  shouldFollowRedirect,
+  verifyModelHash,
+} from "../../src/sherpaEngine";
 
 describe("shouldFollowRedirect", () => {
   it("follows the 302 GitHub returns for a release asset", () => {
@@ -44,5 +50,65 @@ describe("shouldFollowRedirect", () => {
 
   it("does not follow a response with no status code", () => {
     expect(shouldFollowRedirect(undefined, "https://cdn.example/model")).toBe(false);
+  });
+});
+
+describe("redirectLimitExceeded", () => {
+  it("allows the hops a real download needs", () => {
+    // GitHub answers a release asset with one 302 to a CDN host.
+    expect(redirectLimitExceeded(0)).toBe(false);
+    expect(redirectLimitExceeded(1)).toBe(false);
+    expect(redirectLimitExceeded(MAX_REDIRECTS - 1)).toBe(false);
+  });
+
+  it("stops at the limit so a redirect loop cannot recurse forever", () => {
+    expect(redirectLimitExceeded(MAX_REDIRECTS)).toBe(true);
+    expect(redirectLimitExceeded(MAX_REDIRECTS + 1)).toBe(true);
+  });
+
+  it("caps at 5 hops", () => {
+    expect(MAX_REDIRECTS).toBe(5);
+  });
+});
+
+describe("MODEL_SHA256", () => {
+  it("is a full 64-character lowercase hex digest", () => {
+    // A truncated or placeholder constant would fail every download rather
+    // than verify anything, so the shape is worth pinning.
+    expect(MODEL_SHA256).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("verifyModelHash", () => {
+  it("accepts the expected digest", () => {
+    expect(() => verifyModelHash(MODEL_SHA256)).not.toThrow();
+  });
+
+  it("ignores digest casing", () => {
+    expect(() => verifyModelHash(MODEL_SHA256.toUpperCase())).not.toThrow();
+  });
+
+  it("rejects a digest that does not match", () => {
+    const wrong = "0".repeat(64);
+    expect(() => verifyModelHash(wrong)).toThrow(/Model integrity check failed/);
+  });
+
+  it("names both digests so a bug report can tell corruption from substitution", () => {
+    const wrong = "a".repeat(64);
+    let message = "";
+    try {
+      verifyModelHash(wrong, MODEL_SHA256);
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+    expect(message).toContain(MODEL_SHA256.substring(0, 16));
+    expect(message).toContain(wrong.substring(0, 16));
+    // Prefixes only: a full digest pair in a notification is unreadable.
+    expect(message).not.toContain(MODEL_SHA256);
+  });
+
+  it("rejects an empty digest", () => {
+    // A failed hash computation must not read as a pass.
+    expect(() => verifyModelHash("")).toThrow(/Model integrity check failed/);
   });
 });

--- a/tests/unit/stdoutProtocol.test.ts
+++ b/tests/unit/stdoutProtocol.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { parseEngineLine, splitLines } from "../../src/wakeWordCore";
+import { formatConfidence, parseEngineLine, splitLines } from "../../src/wakeWordCore";
 
 describe("parseEngineLine", () => {
   it("parses READY", () => {
@@ -57,6 +57,33 @@ describe("parseEngineLine", () => {
       type: "detected",
       phrase: "a|b|c",
       confidence: 0.75,
+    });
+  });
+
+  it("parses RELEASED", () => {
+    // The sherpa child sends this once mic.stop() has returned. The extension
+    // waits for it before firing the command that takes the microphone.
+    expect(parseEngineLine("RELEASED")).toEqual({ type: "released" });
+    expect(parseEngineLine("  RELEASED\r")).toEqual({ type: "released" });
+  });
+
+  it("does not mistake other output for RELEASED", () => {
+    expect(parseEngineLine("released")).toBeNull();
+    expect(parseEngineLine("RELEASED:now")).toBeNull();
+    expect(parseEngineLine("DEBUG:RELEASED")).toEqual({
+      type: "debug",
+      message: "RELEASED",
+    });
+  });
+
+  it("parses the sherpa DETECTED form, which carries no confidence", () => {
+    // audio-engine.js stopped sending a fabricated |1.0 suffix: the keyword
+    // spotter applies its own threshold and returns no usable score.
+    // SherpaEngine discards the parsed value and emits no confidence at all.
+    expect(parseEngineLine("DETECTED:hey computer")).toEqual({
+      type: "detected",
+      phrase: "hey computer",
+      confidence: 1.0,
     });
   });
 
@@ -135,5 +162,24 @@ describe("splitLines", () => {
 
   it("handles an empty buffer", () => {
     expect(splitLines("")).toEqual({ lines: [], rest: "" });
+  });
+});
+
+describe("formatConfidence", () => {
+  it("renders a real score to two decimal places", () => {
+    expect(formatConfidence(0.923)).toBe(" (confidence: 0.92)");
+    expect(formatConfidence(0)).toBe(" (confidence: 0.00)");
+    expect(formatConfidence(1)).toBe(" (confidence: 1.00)");
+  });
+
+  it("renders nothing when the engine supplied no score", () => {
+    // SherpaEngine reports no confidence rather than a fabricated 1.0, so a
+    // sherpa detection logs as `Detected: "Claude"` with nothing after it.
+    expect(formatConfidence(undefined)).toBe("");
+  });
+
+  it("renders nothing for a non-finite score", () => {
+    expect(formatConfidence(NaN)).toBe("");
+    expect(formatConfidence(Infinity)).toBe("");
   });
 });


### PR DESCRIPTION
Add RELEASED protocol message so the parent confirms mic closure before firing the target command, with a 500ms timeout fallback.

Verify downloaded model against a SHA-256 hash before extraction. Cap redirect hops at 5.

Add --self-test flag to audio-engine.js and run it in CI alongside VSIX packaging to catch dependency and packaging failures on all platforms.

Stop reporting misleading confidence 1.00 for Sherpa detections. Windows Speech detections continue to show real confidence scores.

Change default terminal wake phrase from "Computer" to "Hey Computer" to reduce false positives.

Add Linux ARM64 as a fourth CI and release target.