### PR TITLE
feat: verify engine binary per .vsix, Node 22, latest Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,11 +28,11 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - run: npm ci
 
@@ -49,6 +49,32 @@ jobs:
       # broken engine dependency has shipped a dead release before (v0.5.0).
       - name: Install engine dependencies
         run: cd engine && npm install
+
+      # npm installs only the @decibri platform package whose os/cpu fields
+      # match the runner, so this directory normally holds one package already.
+      # This step turns that into a guarantee: any other platform's binary is
+      # removed, and the build fails unless exactly one package matching the
+      # target remains. The smoke test and the .vsix below then see the tree
+      # that ships.
+      - name: Prune non-target engine binaries
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cd engine/node_modules/@decibri
+          kept=0
+          for dir in */; do
+            case "$dir" in
+              *"$TARGET"*) kept=$((kept + 1)) ;;
+              *) echo "Removing $dir"; rm -rf "$dir" ;;
+            esac
+          done
+          echo "Remaining @decibri packages:"
+          ls -la
+          if [ "$kept" -ne 1 ]; then
+            echo "::error::Expected exactly one @decibri package matching $TARGET, found $kept"
+            exit 1
+          fi
 
       # Loads decibri, sherpa-onnx, and sentencepiece-js on this platform and
       # exits. Catches MODULE_NOT_FOUND and native ABI mismatches, neither of

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,16 +28,42 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
 
       - run: npm ci
 
       - name: Install engine dependencies
         run: cd engine && npm install
+
+      # npm installs only the @decibri platform package whose os/cpu fields
+      # match the runner, so this directory normally holds one package already.
+      # This step turns that into a guarantee: any other platform's binary is
+      # removed, and the build fails unless exactly one package matching the
+      # target remains. The smoke test and the .vsix below then see the tree
+      # that ships.
+      - name: Prune non-target engine binaries
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target }}
+        run: |
+          cd engine/node_modules/@decibri
+          kept=0
+          for dir in */; do
+            case "$dir" in
+              *"$TARGET"*) kept=$((kept + 1)) ;;
+              *) echo "Removing $dir"; rm -rf "$dir" ;;
+            esac
+          done
+          echo "Remaining @decibri packages:"
+          ls -la
+          if [ "$kept" -ne 1 ]; then
+            echo "::error::Expected exactly one @decibri package matching $TARGET, found $kept"
+            exit 1
+          fi
 
       # Fail the release before publishing if the shipped engine tree cannot
       # load on this platform.
@@ -56,7 +82,7 @@ jobs:
 
       # Attach .vsix to the GitHub release
       - name: Upload .vsix to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: wake-word-${{ matrix.target }}-${{ github.event.release.tag_name }}.vsix
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ wake-word/
   .github/
     dependabot.yml     # Dependency updates for both / and /engine
     workflows/
-      ci.yml           # CI: lint, compile, test, engine deps, engine self-test, .vsix package
+      ci.yml           # CI: lint, compile, test, engine deps, binary prune, engine self-test, .vsix package
       release.yml      # CI: build .vsix, publish to Marketplace and Open VSX
 ```
 
@@ -69,7 +69,7 @@ Only the Windows engine produces a real confidence score. sherpa-onnx's keyword 
 
 **SherpaEngine** spawns `engine/audio-engine.js` under system Node.js. The child uses `decibri` (5.7.0) for mic capture and `sherpa-onnx` for keyword spotting. Config is sent as a JSON line to stdin. System Node.js is required because Electron cannot load native addons at the correct ABI.
 
-`decibri` runs with Silero VAD enabled and `audio-engine.js` only feeds audio to the keyword spotter while speech is present, so an idle editor does not run the transducer. decibri emits `'data'` for a chunk *before* it scores that chunk, so the handler holds chunks in a 500 ms pre-roll ring and flushes them when `'speech'` fires; drop the pre-roll and the onset of the wake phrase never reaches the spotter. The `'data'` listener is also what keeps the capture stream pumping, so it must stay unconditional. Capture is conditioned with `dcRemoval`, an 80 Hz `highpass`, and `agc: -18`.
+`decibri` runs with Silero VAD enabled and `audio-engine.js` only feeds audio to the keyword spotter while speech is present, so an idle editor does not run the transducer. decibri emits `'data'` for a chunk *before* it scores that chunk, so the handler holds chunks in a 500 ms pre-roll ring and flushes them when `'speech'` fires; drop the pre-roll and the onset of the wake phrase never reaches the spotter. The `'data'` listener is also what keeps the capture stream pumping, so it must stay unconditional. Capture is conditioned with `dcRemoval`, an 80 Hz `highpass`, and `agc: -18`. The microphone is opened with `Microphone.open()`, decibri's async factory, so the Silero model load runs on the native thread pool instead of blocking the event loop. In debug mode the engine emits `DEBUG:overruns: <n>` whenever decibri's `overrunCount` has changed, checked every 30 seconds; a rising count means the decode loop is falling behind capture.
 
 On wake word detection the microphone is released and the engine process torn down (handoff), then respawned after a cooldown, so only one thing uses the mic at a time. The release is acknowledged, not assumed: `audio-engine.js` sends `RELEASED` once `mic.stop()` has returned and `SherpaEngine.releaseThenKill()` waits for that line before force-killing, capped at 500 ms. `forceKill()` is the unacknowledged path, used by `start()` and `stop()`. The Windows engine has no `RELEASED`, and needs none: System.Speech holds the capture device for the lifetime of the PowerShell process, so process exit is the confirmation.
 
@@ -143,6 +143,8 @@ Manual testing checklist:
 **NEVER** add `darwin-x64` as a CI build target. Intel Mac (pre-2020) is excluded: the `macos-13` GitHub Actions runner has uncertain long-term availability, and `decibri` darwin-x64 pre-built binaries are unconfirmed. Revisit only if a darwin-x64 user files an issue with confirmed binary support.
 
 CI and release build four targets: `win32-x64`, `darwin-arm64`, `linux-x64`, and `linux-arm64`. Linux ARM64 runs on the `ubuntu-24.04-arm` runner label, not a variant of `ubuntu-latest`, which is x64; `decibri` ships a `linux-arm64-gnu` pre-built binary.
+
+Both workflows run on Node 22. After the engine install, each job deletes any `@decibri` platform package that does not match its build target and fails unless exactly one remains, so a `.vsix` never ships another platform's native binary. npm already installs only the package whose `os`/`cpu` fields match the runner; the step turns that into an assertion.
 
 **NEVER** ship a model download without a verified digest. The tarball is fetched over redirects to a CDN and loaded straight into the keyword spotter.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,113 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-## [Unreleased]
+## [0.8.0] - 2026-09-05
+
+### Added
+
+- CI and release now delete any `@decibri` platform package that does not
+  match the build target after the engine install, and fail unless exactly
+  one remains. npm already installs only the package whose `os`/`cpu`
+  fields match the runner, so each `.vsix` has always carried one native
+  binary; the step turns that assumption into an assertion, and the smoke
+  test and package steps now run on the tree that ships.
+
+### Changed
+
+- The audio engine opens the microphone with `Microphone.open()`,
+  decibri's async factory, instead of the synchronous constructor. The
+  Silero VAD model load now runs on the native thread pool rather than
+  blocking the child's event loop for the duration. A stop that arrives
+  while the open is in flight closes the microphone it produced instead
+  of leaving the device held until the process exits.
+- In debug mode the audio engine reports decibri's `overrunCount` as
+  `DEBUG:overruns: <n>` whenever it has changed, checked every 30
+  seconds. A rising count means the keyword spotter's decode loop is
+  falling behind microphone capture. A session with no overruns logs
+  nothing extra.
+- Node.js requirement for the sherpa-onnx engine on macOS and Linux
+  raised from 18 or later to 22 or later. Node 18 and Node 20 have both
+  reached end of life; Node 22 is the oldest line still under long-term
+  support. CI and release now run on Node 22, and `@types/node` moves
+  from the 20 line to the 22 line.
+- GitHub Actions moved to `actions/checkout@v7`, `actions/setup-node@v7`,
+  and `softprops/action-gh-release@v3`, all of which run on the Node 24
+  Actions runtime. This clears the "Node.js 20 is deprecated" warnings
+  the v0.7.0 release workflow produced.
+
+### Fixed
+
+- The changelog entries for v0.6.0 and v0.7.0 were still headed
+  `[Unreleased]` when those versions were tagged. They now have their own
+  sections and release dates.
+
+### Security
+
+- Cleared the two `qs` advisories published on 2026-09-02
+  (GHSA-x5fp-wj9c-mxmx, GHSA-4mjr-xmp4-gh2g), reached through
+  `@vscode/vsce`'s `typed-rest-client`. Build and publish tooling only;
+  nothing in the `.vsix` changes. `npm audit` is back to 0
+  vulnerabilities.
+
+---
+
+## [0.7.0] - 2026-08-24
+
+### Added
+
+- `audio-engine.js --self-test` loads decibri, sherpa-onnx, and
+  sentencepiece-js and exits without opening the microphone. CI runs it
+  on every platform, so a missing module or a native ABI mismatch in the
+  shipped engine tree fails the build instead of the user's install.
+
+### Changed
+
+- The default terminal wake phrase is now "Hey Computer" rather than
+  "Computer". A single common English word is spoken far too often in
+  ordinary conversation to sit behind an always-listening microphone.
+  Customised routes in `settings.json` are unaffected; the defaults only
+  apply when `wakeWord.routes` is empty.
+- The sherpa engine no longer reports a confidence for its detections.
+  Its keyword spotter applies its own threshold and returns no usable
+  score, so every detection was logged as "confidence: 1.00", which made
+  the two engines' logs look comparable when they never were. Windows
+  Speech detections continue to show their real scores.
+- CI and release now build for Linux ARM64 as well, bringing both
+  matrices to four targets: win32-x64, darwin-arm64, linux-x64, and
+  linux-arm64. decibri already ships a linux-arm64 pre-built binary.
+- CI now packages the `.vsix` on every platform. The source tree passing
+  is not evidence the artifact builds: packaging has failed twice, once
+  reaching users as a dead v0.4.0 release.
+
+### Fixed
+
+- Microphone release is now acknowledged rather than assumed. The audio
+  engine sends `RELEASED` once `mic.stop()` has returned, and the
+  extension waits for that line before force-killing the child, up to
+  500 ms. Previously the process was killed and the capture device was
+  assumed torn down by the time the target assistant asked for it, which
+  was only ever usually true. On Windows there is no `RELEASED`:
+  System.Speech holds the device for the lifetime of the PowerShell
+  process, so process exit is the confirmation and it is now logged.
+- A write to an audio engine child that had already exited could take
+  the extension host down. EPIPE arrives as an `error` event on the
+  stream rather than a thrown exception, so the existing `try`/`catch`
+  around each write never covered it and nothing listened for it.
+
+### Security
+
+- The downloaded speech model is now verified against a pinned SHA-256
+  digest before extraction, and a rejected tarball is deleted rather
+  than left on disk. The download follows HTTP redirects to a CDN host
+  and its contents are loaded straight into the keyword spotter, so
+  nothing previously stood between a hijacked redirect and a model of
+  someone else's choosing running on the user's machine.
+- The model download now follows at most 5 redirect hops. A redirect
+  loop previously recursed until the extension host ran out of stack.
+
+---
+
+## [0.6.0] - 2026-08-23
 
 ### Added
 
@@ -21,11 +127,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   parsing, and BPE keyword tokenisation. The suite needs no microphone,
   no child process, no network, and no VS Code API, and runs on all
   three platforms in CI.
-
-- `audio-engine.js --self-test` loads decibri, sherpa-onnx, and
-  sentencepiece-js and exits without opening the microphone. CI runs it
-  on every platform, so a missing module or a native ABI mismatch in the
-  shipped engine tree fails the build instead of the user's install.
 
 ### Changed
 
@@ -55,22 +156,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   three platforms (Windows, macOS, Linux) instead of Ubuntu only. The
   matrix mirrors release.yml so a platform-specific break surfaces on
   the pull request rather than at publish time.
-- The default terminal wake phrase is now "Hey Computer" rather than
-  "Computer". A single common English word is spoken far too often in
-  ordinary conversation to sit behind an always-listening microphone.
-  Customised routes in `settings.json` are unaffected; the defaults only
-  apply when `wakeWord.routes` is empty.
-- The sherpa engine no longer reports a confidence for its detections.
-  Its keyword spotter applies its own threshold and returns no usable
-  score, so every detection was logged as "confidence: 1.00", which made
-  the two engines' logs look comparable when they never were. Windows
-  Speech detections continue to show their real scores.
-- CI and release now build for Linux ARM64 as well, bringing both
-  matrices to four targets: win32-x64, darwin-arm64, linux-x64, and
-  linux-arm64. decibri already ships a linux-arm64 pre-built binary.
-- CI now packages the `.vsix` on every platform. The source tree passing
-  is not evidence the artifact builds: packaging has failed twice, once
-  reaching users as a dead v0.4.0 release.
 
 ### Fixed
 
@@ -94,18 +179,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.vscodeignore`.
 - Fixed `package-lock.json` version drift; the lockfile root version was
   never regenerated for the 0.5.1 bump.
-- Microphone release is now acknowledged rather than assumed. The audio
-  engine sends `RELEASED` once `mic.stop()` has returned, and the
-  extension waits for that line before force-killing the child, up to
-  500 ms. Previously the process was killed and the capture device was
-  assumed torn down by the time the target assistant asked for it, which
-  was only ever usually true. On Windows there is no `RELEASED`:
-  System.Speech holds the device for the lifetime of the PowerShell
-  process, so process exit is the confirmation and it is now logged.
-- A write to an audio engine child that had already exited could take
-  the extension host down. EPIPE arrives as an `error` event on the
-  stream rather than a thrown exception, so the existing `try`/`catch`
-  around each write never covered it and nothing listened for it.
 
 ### Security
 
@@ -119,14 +192,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vulnerabilities. These are build and publish tooling only and never
   shipped to users, but they run with `VSCE_PAT` and `OVSX_PAT` in
   scope during a release.
-- The downloaded speech model is now verified against a pinned SHA-256
-  digest before extraction, and a rejected tarball is deleted rather
-  than left on disk. The download follows HTTP redirects to a CDN host
-  and its contents are loaded straight into the keyword spotter, so
-  nothing previously stood between a hijacked redirect and a model of
-  someone else's choosing running on the user's machine.
-- The model download now follows at most 5 redirect hops. A redirect
-  loop previously recursed until the extension host ran out of stack.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ code --install-extension analytics-in-motion.wake-word
 | Platform | Requirement |
 | --- | --- |
 | Windows 10/11 | No additional software. Uses built-in `System.Speech.Recognition` |
-| macOS | Node.js 18+ (for the speech engine child process) |
-| Linux | Node.js 18+ (for the speech engine child process) |
+| macOS | Node.js 22 or later (LTS) for the speech engine child process |
+| Linux | Node.js 22 or later (LTS) for the speech engine child process |
 
 On macOS and Linux a local speech model (~17MB) is downloaded on first use and cached. If Node.js is installed via nvm or fnm and not on VS Code's PATH, set `wakeWord.nodePath` to the full path of your `node` executable.
 
@@ -301,8 +301,8 @@ All speech recognition runs locally on your machine. No audio data ever leaves y
 | Platform | Status | Engine |
 | --- | --- | --- |
 | Windows 10/11 | Supported | Windows built-in System.Speech |
-| macOS | Supported | sherpa-onnx (requires Node.js 18+) |
-| Linux | Supported | sherpa-onnx (requires Node.js 18+) |
+| macOS | Supported | sherpa-onnx (requires Node.js 22 or later) |
+| Linux | Supported | sherpa-onnx (requires Node.js 22 or later) |
 
 ## Compatibility
 

--- a/engine/audio-engine.js
+++ b/engine/audio-engine.js
@@ -219,9 +219,14 @@ async function main(config) {
   //
   // Conditioning runs dcRemoval -> highpass -> agc on the delivered audio.
   // VAD reads the pre-conditioning signal, so the two are independent.
+  //
+  // Microphone.open() is decibri's async factory. The constructor loads the
+  // Silero model inline and blocks the event loop for the duration; the
+  // factory does the same work on the native thread pool and rejects with
+  // the same error classes, so the catch below is unchanged.
   if (debugMode) debug('opening microphone...');
   try {
-    mic = new Microphone({
+    mic = await Microphone.open({
       sampleRate: 16000,
       channels: 1,
       vad: 'silero',
@@ -231,6 +236,15 @@ async function main(config) {
     });
   } catch (err) {
     fatal(micErrorMessage(err, 'Failed to open microphone'));
+    return;
+  }
+
+  // A stop that arrived while the open was in flight found no microphone to
+  // close and has already sent RELEASED. Close this one now rather than hold
+  // the device until the process exits.
+  if (stopping) {
+    try { mic.stop(); } catch { /* ignore */ }
+    mic = null;
     return;
   }
 
@@ -314,6 +328,23 @@ async function main(config) {
       feed(ready);
     }
   });
+
+  // Debug only: decibri's overrunCount is the number of capture chunks it has
+  // dropped because the consumer fell behind the stream, so a rising figure
+  // means the decode loop cannot keep up with the microphone. Reported only
+  // when it changes, so a session with no overruns produces no output, and
+  // unref'd so the timer never holds the process open on its own.
+  if (debugMode) {
+    let reported = 0;
+    setInterval(() => {
+      if (stopping || !mic) return;
+      const count = mic.overrunCount;
+      if (count !== reported) {
+        debug('overruns: ' + count);
+        reported = count;
+      }
+    }, 30000).unref();
+  }
 
   out('READY');
   if (debugMode) debug('mic open, VAD-gated, listening for: ' + Object.values(phraseMap).join(', '));

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "wake-word",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wake-word",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "Apache-2.0",
       "devDependencies": {
-        "@types/node": "^20.11.0",
+        "@types/node": "^22.0.0",
         "@types/vscode": "~1.85.0",
         "@typescript-eslint/eslint-plugin": "^8.68.0",
         "@typescript-eslint/parser": "^8.69.0",
@@ -1906,9 +1906,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.35",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.35.tgz",
-      "integrity": "sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6075,9 +6075,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for your editor with customizable wake word. Fully local, zero config.",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",
@@ -162,7 +162,7 @@
     "release": "npm run compile && npm run package"
   },
   "devDependencies": {
-    "@types/node": "^20.11.0",
+    "@types/node": "^22.0.0",
     "@types/vscode": "~1.85.0",
     "@typescript-eslint/eslint-plugin": "^8.68.0",
     "@typescript-eslint/parser": "^8.69.0",


### PR DESCRIPTION
Assert exactly one @decibri platform binary is present in the engine tree before packaging. npm already installs only the matching platform binary; the step validates that assumption in CI.

Move CI, release, and @types/node to Node 22 and raise the documented requirement to Node 22 or later. Update actions/checkout, setup-node, and action-gh-release to their Node 24 majors, clearing the Node 20 deprecation warnings.

Open the microphone with Microphone.open() so the Silero VAD load runs off the event loop, and close it if a stop arrived mid-open. Report overrunCount in debug mode when it changes.

Split the changelog's [Unreleased] into [0.7.0] and [0.6.0], add [0.8.0], and clear the qs advisories in the vsce toolchain.