### PR TITLE
feat: multi-window coordination, audio device selection, session stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ wake-word/
     speechEngineInterface.ts  # ISpeechEngine interface (implemented by both engines)
     windowsSpeechEngine.ts    # WindowsSpeechEngine: PowerShell child process using Windows System.Speech
     sherpaEngine.ts           # SherpaEngine: audio-engine.js child process under system Node.js
+    wakeWordCore.ts           # Pure logic shared by the host and both engines, incl. session stats
+    lockFile.ts               # PID lock in globalStorage so only one editor window listens
   engine/
     audio-engine.js           # Child process: decibri VAD-gated mic capture + sherpa-onnx keyword spotting
     package.json              # Engine dependencies (decibri 5.7.0, sherpa-onnx 1.13.6, sentencepiece-js 1.1.0)
@@ -45,6 +47,7 @@ wake-word/
     unit/              # TypeScript tests for the extension host code
     engine/            # JavaScript tests for engine/lib
     mocks/vscode.ts    # Stub for the `vscode` module, wired up in vitest.config.mts
+    mocks/childProcess.ts  # MockChildProcess: drives the engine state machine without a real process
   scripts/
     check-readme.js    # Lint-time check: blocks vsce-restricted SVGs in README.md
   dist/                # Compiled JS output (do not edit)
@@ -69,11 +72,19 @@ Only the Windows engine produces a real confidence score. sherpa-onnx's keyword 
 
 **SherpaEngine** spawns `engine/audio-engine.js` under system Node.js. The child uses `decibri` (5.7.0) for mic capture and `sherpa-onnx` for keyword spotting. Config is sent as a JSON line to stdin. System Node.js is required because Electron cannot load native addons at the correct ABI.
 
+The config line carries `audioDevice`, the `wakeWord.audioDevice` setting, which `engine/lib/control.js` resolves to decibri's `device` option: a digit-only string is a device index, anything else a case-insensitive name substring, and empty means the system default (the key is omitted). A lookup failure is reported by `engine/lib/mic-errors.js` with the value and the setting named. The extension builds a new `SherpaEngine` when the setting changes, as it does for `wakeWord.nodePath`. The Windows engine ignores the setting: `System.Speech` is bound to the default input device.
+
 `decibri` runs with Silero VAD enabled and `audio-engine.js` only feeds audio to the keyword spotter while speech is present, so an idle editor does not run the transducer. decibri emits `'data'` for a chunk *before* it scores that chunk, so the handler holds chunks in a 500 ms pre-roll ring and flushes them when `'speech'` fires; drop the pre-roll and the onset of the wake phrase never reaches the spotter. The `'data'` listener is also what keeps the capture stream pumping, so it must stay unconditional. Capture is conditioned with `dcRemoval`, an 80 Hz `highpass`, and `agc: -18`. The microphone is opened with `Microphone.open()`, decibri's async factory, so the Silero model load runs on the native thread pool instead of blocking the event loop. In debug mode the engine emits `DEBUG:overruns: <n>` whenever decibri's `overrunCount` has changed, checked every 30 seconds; a rising count means the decode loop is falling behind capture.
 
 On wake word detection the microphone is released and the engine process torn down (handoff), then respawned after a cooldown, so only one thing uses the mic at a time. The release is acknowledged, not assumed: `audio-engine.js` sends `RELEASED` once `mic.stop()` has returned and `SherpaEngine.releaseThenKill()` waits for that line before force-killing, capped at 500 ms. `forceKill()` is the unacknowledged path, used by `start()` and `stop()`. The Windows engine has no `RELEASED`, and needs none: System.Speech holds the capture device for the lifetime of the PowerShell process, so process exit is the confirmation.
 
 `pause()` stays synchronous and the target command still fires as soon as it returns; the release completes underneath within the timeout. Ordering the command strictly after `RELEASED` is a handoff policy change and should be designed separately.
+
+Both engines cancel a pending crash-backoff retry in `stop()`, `pause()`, and `start()`. `stop()` is the privacy case (Disable must disable); `pause()` during backoff leaves the engine paused with no process so `resume()` restarts it; `start()` during backoff supersedes the retry rather than letting it fire into the fresh child. `stop()` also kills the child before its state guard: between spawn and `READY` the engine is neither listening nor paused, and an early return there left the child to finish starting and open the microphone after a Disable.
+
+**Multi-window coordination.** Every editor window runs its own extension host and each one activates this extension, so without coordination three windows meant three engine processes on one microphone. `lockFile.ts` implements a PID lock at `<globalStorage>/wake-word.lock`. `startListening()` takes the lock before starting the engine; a window that cannot take it shows "Wake: Other window" and polls every `LOCK_CHECK_INTERVAL_MS` (10 s) until the holder's PID is gone or the file is removed, then starts. The lock is held across pause and cooldown, released by `stopListening()` (Disable, toggle off, consent reset, deactivate), and taken over when its PID is dead or the file is corrupt. Creation uses the `wx` flag so windows that start at the same moment cannot both win. Known limits: different editor products have separate global storage and do not see each other's lock; a window stuck in the error state keeps the lock until listening is disabled there or it closes; PID reuse after a crash can make a stale lock read as live until that process exits.
+
+**Session statistics.** `extension.ts` keeps a `SessionStats` record (defined in `wakeWordCore.ts`): detections per route label, errors, engine starts, cooldowns, and a start time. `formatSessionStats()` renders it as one log line, written on deactivate and before an engine switch resets the counters. No storage, no network.
 
 The model download verifies the tarball against the pinned `MODEL_SHA256` in `sherpaEngine.ts` before extraction, and follows at most `MAX_REDIRECTS` (5) hops. Changing `MODEL_URL` or `MODEL_VERSION` means recomputing that digest; the command to do so is in the constant's comment.
 
@@ -106,13 +117,23 @@ Use semantic versioning bumps. Commit changelog updates as `docs(changelog): upd
 ## Testing
 
 Automated tests run under [vitest](https://vitest.dev) with `npm test`. They
-cover pure logic only: no microphone, no child processes, no network, and no
-VS Code API. `vitest.config.mts` aliases the `vscode` module to
-`tests/mocks/vscode.ts` so src modules that import it can still be loaded, and
-that stub throws if a test actually calls into the API.
+cover pure logic and the engine state machine: no microphone, no real child
+processes, no network, and no VS Code API. `vitest.config.mts` aliases the
+`vscode` module to `tests/mocks/vscode.ts` so src modules that import it can
+still be loaded, and that stub throws if a test actually calls into the API.
 
 - `tests/unit/` is TypeScript and imports from `src/`.
 - `tests/engine/` is JavaScript and imports from `engine/lib/`.
+
+`tests/unit/engineLifecycle.test.ts` drives `SherpaEngine` end to end with
+`child_process.spawn` mocked to return a `MockChildProcess`
+(`tests/mocks/childProcess.ts`), `fs` mocked so the model reads as already
+downloaded, and timers faked. The mock's `sendLine()`, `simulateExit()`, and
+`simulateError()` stand in for the child, so start/stop/pause/resume, the
+crash and retry backoff, the retry cancellation in `stop()` and `pause()`,
+and the `RELEASED` timeout are all asserted rather than checked by hand.
+`tests/unit/lockFile.test.ts` does the same for the multi-window lock with
+an in-memory `fs` that honours the `wx` flag.
 
 Anything that needs a real microphone, a live child process, or the extension
 host still has to be checked by hand. Add a test for pure logic first; if that
@@ -131,6 +152,9 @@ Manual testing checklist:
 8. Output panel shows "Wake Word" channel with timestamped logs
 9. Change `wakeWord.engine` in Settings while listening. Confirm engine restarts immediately and engine indicator updates.
 10. Change `wakeWord.engine` during cooldown. Confirm countdown continues and the new engine starts when it expires.
+11. Open a second window. Its status bar shows "Wake: Other window" and the first keeps listening. Close the first window; within about 10 s the second shows "Wake: Listening".
+12. With the sherpa engine, set `wakeWord.audioDevice` to part of a connected microphone's name. Confirm the engine restarts and the "Starting:" log line names the device. Set it to a name that matches nothing and confirm the error notification names that value.
+13. Switch `wakeWord.engine` after a few detections and confirm a "Session:" line with per-phrase counts appears in the output channel. The same line is written on deactivate, which in the Extension Development Host shows in the debug console.
 
 ## Boundaries
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [0.9.0] - 2026-09-05
+
+### Added
+
+- Multi-window listener coordination. Only one editor window listens at a
+  time. The first window to start listening writes a PID lock to the
+  extension's global storage; any other window shows "Wake: Other window"
+  in the status bar and checks every 10 seconds whether the lock holder
+  has gone. It takes over automatically when the owning window closes,
+  crashes, or has listening disabled. The lock is held through the
+  cooldown after a detection, so a second window cannot open the
+  microphone while an assistant has it. The lock is created exclusively,
+  so windows restored together on editor startup cannot both win it.
+  Windows of different editor products keep separate global storage and
+  do not see each other's lock.
+- `wakeWord.audioDevice` setting for choosing the microphone. Accepts a
+  case-insensitive substring of the device name (`"USB"`, `"Blue Yeti"`)
+  or a device index (`"1"`). Empty means the system default. The value is
+  passed to decibri's `device` option in the audio engine. A name that
+  matches nothing, a name that matches more than one device, and an index
+  past the end of the device list each produce an error that names the
+  value and the setting. Applies to the sherpa engine; the Windows engine
+  always uses the system default input.
+- Session statistics. On deactivation, and before an engine switch resets
+  the counters, the output channel gets one line: session length in
+  minutes, detections per phrase, errors, engine starts, and cooldowns.
+  Nothing is stored or sent anywhere.
+- Engine lifecycle tests against a mock child process: start, stop,
+  pause, resume, the stdout protocol, crash and retry backoff, the retry
+  cancellation that `stop()` and `pause()` must perform, and the
+  `RELEASED` handshake with its 500 ms timeout. These paths were
+  previously covered only by the manual checklist.
+
+### Changed
+
+- Changing `wakeWord.audioDevice` restarts the engine, as changing
+  `wakeWord.engine` or `wakeWord.nodePath` already did.
+
+### Fixed
+
+- `stop()` did nothing to a child that had been spawned but had not yet
+  reported `READY`, because during that window the engine is neither
+  listening nor paused and the state guard returned early. The child then
+  finished loading, opened the microphone, and reported `READY` to an
+  engine the user had stopped. Disable Listening, Reset Microphone
+  Consent, and an engine switch all reached this path if used within the
+  first second or two of a start, and the engine switch case left the old
+  child holding the microphone alongside the new one. Both engines now
+  kill any child they have before checking state. Found by the new
+  lifecycle tests.
+- `pause()` during crash backoff left the retry timer armed, so an engine
+  that had been told to pause could reopen the microphone when the timer
+  fired. The extension never reached this path, because it checks
+  `isListening` before pausing, but the engine's own contract was wrong.
+  Both engines now cancel the retry and become resumable.
+- `start()` during crash backoff also left the retry timer armed, so it
+  could fire into the fresh child: a no-op if `READY` had arrived by then,
+  otherwise a needless kill and respawn in the middle of the model load.
+  Reachable by clicking the status bar during the backoff. Both engines
+  now cancel the retry on start.
+
+---
+
 ## [0.8.0] - 2026-09-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -218,6 +218,12 @@ When a wake phrase is detected:
 
 This ensures only one thing uses the mic at a time.
 
+### Multiple windows
+
+If you have more than one editor window open, only one listens at a time. The first window to start listening takes a lock; the others show **Wake: Other window** in the status bar and stand by. When the listening window closes, crashes, or has listening disabled, a standing-by window takes over within about ten seconds. The lock is held through the cooldown after a detection, so a second window never opens the microphone while an assistant has it.
+
+The lock lives in the extension's global storage, which windows of the same editor share. Windows of different editor products do not see each other's lock.
+
 ## Settings
 
 | Setting | Default | Description |
@@ -230,6 +236,19 @@ This ensures only one thing uses the mic at a time.
 | `wakeWord.confidenceThreshold` | `0.3` | Minimum confidence score (0.1–0.9) for wake phrase detection |
 | `wakeWord.engine` | `auto` | Speech engine: `auto` (platform default), `windows` (System.Speech), or `sherpa` (cross-platform) |
 | `wakeWord.nodePath` | `""` | Path to Node.js executable. Leave empty to auto-detect. Set this if the engine cannot find Node.js (macOS/Linux with nvm or fnm). |
+| `wakeWord.audioDevice` | `""` | Microphone to use: a case-insensitive substring of the device name (e.g. `"USB"`) or a device index. Empty for the system default. Sherpa engine only. |
+
+### Choosing a microphone
+
+`wakeWord.audioDevice` selects the input device for the sherpa engine. Use any case-insensitive substring of the device name as it appears in your system sound settings, or the device's index number:
+
+```json
+{
+  "wakeWord.audioDevice": "Blue Yeti"
+}
+```
+
+Changing it restarts the engine. If the value matches no device, or more than one, the error notification says so and names the value. The Windows engine (`System.Speech`) always uses the system default input device, so set `wakeWord.engine` to `sherpa` to choose a device on Windows.
 
 ## Commands
 
@@ -255,7 +274,7 @@ Useful values for the `command` field in your routes. Command IDs listed are for
 
 ## How It Works (Technical)
 
-The extension selects a speech engine based on platform (or the `wakeWord.engine` setting) and spawns it as a background child process. Both engines communicate via stdout using the same protocol: `READY`, `DETECTED:<phrase>|<confidence>`, `ERROR:<message>`, `DEBUG:<info>`.
+The extension selects a speech engine based on platform (or the `wakeWord.engine` setting) and spawns it as a background child process. Both engines communicate via stdout using the same protocol: `READY`, `DETECTED:<phrase>|<confidence>`, `ERROR:<message>`, `DEBUG:<info>`. The sherpa engine also sends `RELEASED` once it has closed the microphone.
 
 ### Windows engine (default on Windows)
 
@@ -291,6 +310,9 @@ Zero runtime npm dependencies in the extension host. All native dependencies are
 | Microphone access denied (macOS) | Open System Settings → Privacy & Security → Microphone and enable access for VS Code (or your editor). |
 | Model download fails | Check your internet connection. The model is ~17MB downloaded from GitHub. If behind a proxy, ensure HTTPS traffic to `github.com` is allowed. |
 | High CPU while idle (macOS/Linux) | The sherpa engine gates keyword spotting on voice activity detection, so a quiet room should cost close to nothing. Sustained CPU with no one speaking usually means a noisy input: check the correct microphone is selected and lower its input gain. |
+| Status bar shows "Wake: Other window" | Another window of the same editor is listening. Only one listens at a time, and this window takes over automatically when that one stops. To move listening here now, disable it in the other window. |
+| Wrong microphone is used | With the sherpa engine, set `wakeWord.audioDevice` to part of the device's name (e.g. `"USB"`) or its index. The Windows engine always uses the system default input; change that in Windows sound settings. |
+| "No microphone matching ... was found" | The `wakeWord.audioDevice` value did not match any input device. Compare it with the device names in your system sound settings, or clear it to use the default. |
 
 ## Privacy
 

--- a/engine/audio-engine.js
+++ b/engine/audio-engine.js
@@ -25,7 +25,9 @@
  *   { phrases: [{phrase: string, label: string}],
  *     threshold: number,
  *     modelDir: string,
- *     debugMode: boolean }
+ *     debugMode: boolean,
+ *     audioDevice: string }     "" for the system default, otherwise a
+ *                               device index or a name substring
  *
  * Stop: close stdin or send "stop\n" on stdin.
  *
@@ -62,7 +64,12 @@ require.main.paths.unshift(path.join(engineDir, 'node_modules'));
 const { modelPath } = require('./lib/model-path');
 const { VadGate } = require('./lib/vad-gate');
 const { buildKeywordSpec } = require('./lib/keywords');
-const { drainLines, parseControlLine, clampKeywordThreshold } = require('./lib/control');
+const {
+  drainLines,
+  parseControlLine,
+  clampKeywordThreshold,
+  withAudioDevice,
+} = require('./lib/control');
 const { micErrorMessage } = require('./lib/mic-errors');
 
 let mic = null;
@@ -145,7 +152,7 @@ function runSelfTest() {
 }
 
 async function main(config) {
-  const { phrases, threshold, modelDir, debugMode } = config;
+  const { phrases, threshold, modelDir, debugMode, audioDevice } = config;
 
   if (debugMode) debug('audio-engine starting, modelDir=' + modelDir);
 
@@ -224,18 +231,32 @@ async function main(config) {
   // Silero model inline and blocks the event loop for the duration; the
   // factory does the same work on the native thread pool and rejects with
   // the same error classes, so the catch below is unchanged.
-  if (debugMode) debug('opening microphone...');
-  try {
-    mic = await Microphone.open({
+  //
+  // `device` is added only when wakeWord.audioDevice names one: a device
+  // index or a case-insensitive name substring. Absent, decibri opens the
+  // system default input. See lib/control.js.
+  const micOptions = withAudioDevice(
+    {
       sampleRate: 16000,
       channels: 1,
       vad: 'silero',
       dcRemoval: true,
       highpass: 80,
       agc: -18,
-    });
+    },
+    audioDevice
+  );
+  if (debugMode) {
+    debug(
+      'opening microphone' +
+        (micOptions.device === undefined ? '' : ' (device: ' + JSON.stringify(micOptions.device) + ')') +
+        '...'
+    );
+  }
+  try {
+    mic = await Microphone.open(micOptions);
   } catch (err) {
-    fatal(micErrorMessage(err, 'Failed to open microphone'));
+    fatal(micErrorMessage(err, 'Failed to open microphone', audioDevice));
     return;
   }
 
@@ -249,7 +270,7 @@ async function main(config) {
   }
 
   mic.on('error', (err) => {
-    fatal(micErrorMessage(err, 'Microphone error'));
+    fatal(micErrorMessage(err, 'Microphone error', audioDevice));
   });
 
   // VAD gating.

--- a/engine/lib/control.js
+++ b/engine/lib/control.js
@@ -58,4 +58,50 @@ function clampKeywordThreshold(threshold) {
   return Math.max(0.1, Math.min(0.9, threshold || 0.25));
 }
 
-module.exports = { drainLines, parseControlLine, clampKeywordThreshold };
+/**
+ * Resolve the `wakeWord.audioDevice` setting into decibri's `device` option.
+ *
+ * decibri accepts a device index (number) or a case-insensitive substring of
+ * the device name (string). The setting is a string, so a value that is
+ * nothing but digits is taken as an index and anything else as a name. Only
+ * a pure digit string counts: parseInt would read "2nd mic" as index 2 and
+ * silently open the wrong device. Empty, blank, and non-string values mean
+ * the system default, which is what decibri does when the option is absent.
+ *
+ * @returns {number | string | undefined}
+ */
+function resolveAudioDevice(value) {
+  if (typeof value === 'number') {
+    return Number.isInteger(value) && value >= 0 ? value : undefined;
+  }
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  return /^\d+$/.test(trimmed) ? parseInt(trimmed, 10) : trimmed;
+}
+
+/**
+ * Copy the microphone options with `device` set when a device was chosen,
+ * and without the key at all when it was not, so decibri falls back to the
+ * system default rather than being handed `device: undefined`.
+ */
+function withAudioDevice(options, value) {
+  const out = Object.assign({}, options);
+  const device = resolveAudioDevice(value);
+  if (device !== undefined) {
+    out.device = device;
+  }
+  return out;
+}
+
+module.exports = {
+  drainLines,
+  parseControlLine,
+  clampKeywordThreshold,
+  resolveAudioDevice,
+  withAudioDevice,
+};

--- a/engine/lib/mic-errors.js
+++ b/engine/lib/mic-errors.js
@@ -1,21 +1,53 @@
 'use strict';
 
+const SETTING = 'wakeWord.audioDevice';
+
 /**
  * Map decibri's typed errors to something a user can act on.
  *
  * decibri 5.x raises DecibriError subclasses (DeviceError, OrtError,
  * OrtPathError) each carrying a stable `code`. Anything unrecognised falls
  * back to the raw message under the caller's prefix.
+ *
+ * `device` is the value of `wakeWord.audioDevice` when the user configured
+ * one. A lookup failure then names the setting and the value: "no microphone
+ * found" is the wrong diagnosis on a machine with three microphones where the
+ * name simply did not match any of them.
  */
-function micErrorMessage(err, fallbackPrefix) {
+function micErrorMessage(err, fallbackPrefix, device) {
   const code = err && err.code;
   const message = (err && err.message) || String(err);
+  const chosen = device === undefined || device === null ? '' : String(device).trim();
+
+  // An index past the end of the device list is a plain RangeError from
+  // decibri's JS wrapper, with no code to switch on.
+  if (chosen && typeof message === 'string' && message.startsWith('device index out of range')) {
+    return (
+      'Microphone index ' + chosen + ' is out of range. ' +
+      'Check ' + SETTING + ' against the input devices on this machine.'
+    );
+  }
 
   switch (code) {
-    case 'NO_MICROPHONE_FOUND':
     case 'MICROPHONE_NOT_FOUND':
+      if (chosen) {
+        return (
+          'No microphone matching "' + chosen + '" was found. ' +
+          'Check ' + SETTING + ' against the input devices on this machine.'
+        );
+      }
       return 'No microphone found. Check your audio device settings.';
+    case 'NO_MICROPHONE_FOUND':
+      return 'No microphone found. Check your audio device settings.';
+    case 'MULTIPLE_DEVICES_MATCH':
+      return (
+        'More than one microphone matches "' + (chosen || 'the requested name') + '". ' +
+        'Use a longer name or the device index in ' + SETTING + '.'
+      );
     case 'NOT_AN_INPUT_DEVICE':
+      if (chosen) {
+        return 'The audio device "' + chosen + '" is not a microphone. Check ' + SETTING + '.';
+      }
       return 'The selected audio device is not a microphone. Check your audio device settings.';
     case 'PERMISSION_DENIED':
       return 'Microphone access denied. Enable microphone access for VS Code in your system privacy settings.';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wake-word",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wake-word",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "wake-word",
   "displayName": "Wake Word",
   "description": "Voice control for your editor with customizable wake word. Fully local, zero config.",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "Apache-2.0",
   "icon": "icon.png",
   "publisher": "analytics-in-motion",
@@ -144,6 +144,11 @@
             "Force sherpa-onnx keyword spotting engine (cross-platform, requires model download)."
           ],
           "description": "Speech engine to use. Leave on 'auto' unless testing a specific engine."
+        },
+        "wakeWord.audioDevice": {
+          "type": "string",
+          "default": "",
+          "description": "Microphone to listen on. Leave empty for the system default. Use a case-insensitive substring of the device name (e.g. 'USB' or 'Blue Yeti') or the device index number. Applies to the sherpa engine; the Windows engine always uses the system default."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,12 +5,22 @@ import { WindowsSpeechEngine } from "./windowsSpeechEngine";
 import { SherpaEngine } from "./sherpaEngine";
 import {
   DETECTION_DEBOUNCE_MS,
+  SessionStats,
   clampThreshold,
+  createSessionStats,
   formatConfidence,
+  formatSessionStats,
+  recordDetection,
   resolveRoutes,
   selectEngineKind,
   shouldDebounce,
 } from "./wakeWordCore";
+import {
+  LOCK_CHECK_INTERVAL_MS,
+  lockFilePath,
+  releaseLock,
+  tryAcquireLock,
+} from "./lockFile";
 
 let statusBarItem: vscode.StatusBarItem;
 let engineBarItem: vscode.StatusBarItem;
@@ -22,6 +32,10 @@ let isStarting = false;
 let isDevMode = false;
 let isPausedByFocus = false;
 let lastDetectionTime = 0;
+let lockPath = "";
+let lockWatchTimer: ReturnType<typeof setInterval> | null = null;
+let sessionStats: SessionStats = createSessionStats();
+let warnedDeviceIgnored = false;
 
 // ── Default routes ──────────────────────────────────────────
 
@@ -55,7 +69,19 @@ function createEngine(context: vscode.ExtensionContext): ISpeechEngine {
   if (selectEngineKind(engineOverride, os.platform()) === "windows") {
     return new WindowsSpeechEngine();
   }
-  return new SherpaEngine(context, nodePath);
+  return new SherpaEngine(context, nodePath, readAudioDevice(config));
+}
+
+/**
+ * The configured microphone, trimmed, always as a string.
+ *
+ * The schema says string, but settings.json is not validated against it, so
+ * a bare number is accepted and rendered as its digits; the child reads a
+ * digit-only string as a device index.
+ */
+function readAudioDevice(config: vscode.WorkspaceConfiguration): string {
+  const value = config.get<unknown>("audioDevice", "");
+  return value === undefined || value === null ? "" : String(value).trim();
 }
 
 // ── Engine wiring ────────────────────────────────────────────
@@ -64,12 +90,16 @@ function wireEngine(engine: ISpeechEngine): void {
   engine.on("detected", (phrase: WakePhrase, confidence?: number) => {
     onWakeWordDetected(phrase, confidence);
   });
-  engine.on("started", () => setStatusBar("listening"));
+  engine.on("started", () => {
+    sessionStats.engineStarts++;
+    setStatusBar("listening");
+  });
   engine.on("paused", () => setStatusBar("handed-off"));
   engine.on("stopped", () => setStatusBar("off"));
   engine.on("debug", (info: string) => log("info", info));
   engine.on("warning", (msg: string) => log("warn", msg));
   engine.on("error", (err: Error) => {
+    sessionStats.errors++;
     log("error", err.message);
     vscode.window.showErrorMessage(`Wake Word error: ${err.message}`, "Show Log").then((choice) => {
       if (choice === "Show Log") {
@@ -88,6 +118,11 @@ export function activate(context: vscode.ExtensionContext) {
 
   outputChannel = vscode.window.createOutputChannel("Wake Word");
   context.subscriptions.push(outputChannel);
+
+  // Shared by every window of this editor, which is what lets them agree on
+  // who holds the microphone. See lockFile.ts.
+  lockPath = lockFilePath(context.globalStorageUri.fsPath);
+  sessionStats = createSessionStats();
 
   speechEngine = createEngine(context);
   wireEngine(speechEngine);
@@ -143,7 +178,9 @@ export function activate(context: vscode.ExtensionContext) {
     })
   );
 
-  // Auto-start if configured (deferred to let VS Code finish initialising)
+  // Auto-start if configured (deferred to let VS Code finish initialising).
+  // If another window already holds the listener lock, startListening()
+  // stands this window down and watches for its turn.
   const config = vscode.workspace.getConfiguration("wakeWord");
   const autoStart = config.get<boolean>("enableOnStartup", true);
   if (autoStart) {
@@ -157,17 +194,23 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.workspace.onDidChangeConfiguration((e) => {
       const engineChanged =
         e.affectsConfiguration("wakeWord.engine") ||
-        e.affectsConfiguration("wakeWord.nodePath");
+        e.affectsConfiguration("wakeWord.nodePath") ||
+        e.affectsConfiguration("wakeWord.audioDevice");
 
       if (engineChanged) {
         const wasListening = speechEngine.isListening;
         const cooldownActive = countdownTimer !== null;
         isPausedByFocus = false;
         lastDetectionTime = 0;
+        warnedDeviceIgnored = false;
         speechEngine.dispose();
         speechEngine = createEngine(context);
         wireEngine(speechEngine);
         log("info", "Engine switched due to settings change");
+        // The counters describe one engine's run. Write them out before
+        // they are reset for the new one.
+        logSessionStats();
+        sessionStats = createSessionStats();
         updateEngineIndicator(cooldownActive);
         if (cooldownActive) {
           log("info", "Engine switched during cooldown — will start when cooldown expires");
@@ -207,6 +250,9 @@ export function activate(context: vscode.ExtensionContext) {
 
 export function deactivate() {
   if (speechEngine) {
+    logSessionStats();
+    // stopListening() also stops the lock watcher and releases the lock, so
+    // a window that closes hands the microphone to the next one.
     stopListening();
     speechEngine.dispose();
   }
@@ -268,6 +314,10 @@ function log(level: "info" | "warn" | "error", message: string) {
   }
 }
 
+function logSessionStats(): void {
+  log("info", formatSessionStats(sessionStats));
+}
+
 // ── Core logic ──────────────────────────────────────────────
 
 function startListening() {
@@ -281,18 +331,88 @@ function startListening() {
     return;
   }
 
+  // Only one window listens at a time. The lock is held for the whole
+  // session, cooldowns included, and re-acquiring one we already hold is a
+  // no-op, so calling this on every start is safe.
+  if (!acquireListenerLock()) {
+    log("info", "Another editor window is listening. This window will take over if it stops.");
+    setStatusBar("other-window");
+    startLockWatcher();
+    return;
+  }
+  stopLockWatcher();
+
   const threshold = clampThreshold(config.get<number>("confidenceThreshold", 0.3));
-  log("info", `Starting: ${routes.length} routes, threshold=${threshold}, devMode=${isDevMode}`);
+  const audioDevice = readAudioDevice(config);
+  const deviceNote = audioDevice ? `, device="${audioDevice}"` : "";
+  log("info", `Starting: ${routes.length} routes, threshold=${threshold}, devMode=${isDevMode}${deviceNote}`);
   log("info", `OS: ${process.platform} ${process.arch}, VS Code: ${vscode.version}`);
+
+  if (audioDevice && !(speechEngine instanceof SherpaEngine) && !warnedDeviceIgnored) {
+    warnedDeviceIgnored = true;
+    log(
+      "warn",
+      "wakeWord.audioDevice is set, but the Windows engine always uses the system " +
+        "default microphone. Set wakeWord.engine to \"sherpa\" to choose a device."
+    );
+  }
+
   speechEngine.start(routes, threshold, isDevMode);
 }
 
 function stopListening() {
   clearResumeTimer();
+  stopLockWatcher();
   isPausedByFocus = false;
   lastDetectionTime = 0;
   speechEngine.stop();
+  releaseLock(lockPath);
   setStatusBar("off");
+}
+
+// ── Multi-window coordination ───────────────────────────────
+
+/**
+ * Take the listener lock, or report that another window holds it.
+ *
+ * A storage directory that cannot be written is not a reason to stay
+ * silent: log it and listen without coordination, which is what every
+ * version before this one did.
+ */
+function acquireListenerLock(): boolean {
+  try {
+    return tryAcquireLock(lockPath);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    log("warn", `Could not write the listener lock (${message}). Listening without multi-window coordination.`);
+    return true;
+  }
+}
+
+/**
+ * While another window holds the lock, check every LOCK_CHECK_INTERVAL_MS
+ * whether it has gone: closed cleanly and released, or crashed and left a
+ * lock naming a dead process. Either way this window takes over.
+ */
+function startLockWatcher(): void {
+  if (lockWatchTimer) {
+    return;
+  }
+  lockWatchTimer = setInterval(() => {
+    if (!acquireListenerLock()) {
+      return;
+    }
+    stopLockWatcher();
+    log("info", "The listening window has stopped. Taking over.");
+    startListening();
+  }, LOCK_CHECK_INTERVAL_MS);
+}
+
+function stopLockWatcher(): void {
+  if (lockWatchTimer) {
+    clearInterval(lockWatchTimer);
+    lockWatchTimer = null;
+  }
 }
 
 // ── Route configuration ─────────────────────────────────────
@@ -311,6 +431,7 @@ async function onWakeWordDetected(phrase: WakePhrase, confidence?: number) {
     return;
   }
   lastDetectionTime = now;
+  recordDetection(sessionStats, phrase.label);
 
   // Only the Windows engine supplies a score; formatConfidence renders
   // nothing when there is none to show.
@@ -358,6 +479,7 @@ async function onWakeWordDetected(phrase: WakePhrase, confidence?: number) {
 function scheduleResume(seconds: number) {
   clearResumeTimer();
   countdownRemaining = seconds;
+  sessionStats.cooldowns++;
 
   statusBarItem.text = `$(clock) Wake: ${countdownRemaining}s`;
   statusBarItem.tooltip = "Mic handed off to assistant. Resuming soon.";
@@ -410,7 +532,7 @@ function updateEngineIndicator(visible: boolean): void {
   engineBarItem.show();
 }
 
-function setStatusBar(state: "off" | "listening" | "handed-off" | "error") {
+function setStatusBar(state: "off" | "listening" | "handed-off" | "error" | "other-window") {
   switch (state) {
     case "off":
       statusBarItem.text = "$(mic-off) Wake: Off";
@@ -440,6 +562,14 @@ function setStatusBar(state: "off" | "listening" | "handed-off" | "error") {
       statusBarItem.backgroundColor = new vscode.ThemeColor(
         "statusBarItem.errorBackground"
       );
+      updateEngineIndicator(false);
+      break;
+    case "other-window":
+      statusBarItem.text = "$(mic-off) Wake: Other window";
+      statusBarItem.tooltip =
+        "Another editor window is already listening. Only one instance listens " +
+        "at a time. This window takes over automatically when that one stops.";
+      statusBarItem.backgroundColor = undefined;
       updateEngineIndicator(false);
       break;
   }

--- a/src/lockFile.ts
+++ b/src/lockFile.ts
@@ -1,0 +1,192 @@
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from "fs";
+import * as path from "path";
+
+/**
+ * Cross-window listener coordination.
+ *
+ * Every editor window runs its own extension host, and each one activates
+ * this extension. Without coordination three windows meant three engine
+ * processes on the same microphone, three detections of one phrase, and
+ * three commands firing at once. The fix is a PID lock in globalStorage,
+ * which every window of the same editor shares: the first window to start
+ * listening writes its extension host PID, and the others stand down until
+ * that PID is gone.
+ *
+ * The lock is held for the whole listening session, including the cooldown
+ * after a detection: the microphone is handed to an assistant then, and a
+ * second window must not grab it in the meantime. It is released when the
+ * user disables listening in the owning window and when that window's
+ * extension host deactivates. A crash releases nothing, so a lock whose PID
+ * is no longer running is treated as free.
+ *
+ * Nothing here touches the VS Code API. The extension host passes the storage
+ * directory in, so this module is unit tested with the filesystem mocked.
+ */
+
+export const LOCK_FILE_NAME = "wake-word.lock";
+
+/** How often a standing-by window checks whether the lock holder has gone. */
+export const LOCK_CHECK_INTERVAL_MS = 10_000;
+
+export interface LockInfo {
+  /** Extension host PID of the window that is listening. */
+  pid: number;
+  /** ISO timestamp of when that window took the lock. Informational. */
+  startedAt: string;
+}
+
+export type LockState =
+  | { kind: "absent" }
+  | { kind: "corrupt" }
+  | { kind: "held"; lock: LockInfo };
+
+export interface AcquireOptions {
+  /** PID written to the lock and recognised as our own. Defaults to process.pid. */
+  ownPid?: number;
+  /** Liveness probe for a foreign PID. Defaults to isProcessAlive. */
+  isAlive?: (pid: number) => boolean;
+  /** Clock for the startedAt stamp. */
+  now?: () => Date;
+}
+
+/** Path of the lock file inside the extension's global storage directory. */
+export function lockFilePath(storageDir: string): string {
+  return path.join(storageDir, LOCK_FILE_NAME);
+}
+
+/**
+ * True when a process with this PID is running.
+ *
+ * Signal 0 delivers nothing and only checks that the target exists, on
+ * Windows as well as POSIX. EPERM means the process exists but belongs to
+ * another user, which still counts as alive. Zero and negative values address
+ * process groups rather than a process, and kill(0, 0) succeeds without
+ * saying anything about a lock holder, so they are rejected up front.
+ */
+export function isProcessAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return false;
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * Read and validate the lock file.
+ *
+ * A missing file is `absent`. Anything that is not a JSON object with a
+ * positive integer `pid` is `corrupt`; the caller treats that the same as a
+ * stale lock, because a file that cannot name its owner cannot be honoured.
+ */
+export function readLock(lockPath: string): LockState {
+  let raw: string;
+  try {
+    raw = readFileSync(lockPath, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { kind: "absent" };
+    }
+    return { kind: "corrupt" };
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return { kind: "corrupt" };
+    }
+    const pid = (parsed as { pid?: unknown }).pid;
+    if (typeof pid !== "number" || !Number.isInteger(pid) || pid <= 0) {
+      return { kind: "corrupt" };
+    }
+    const startedAt = (parsed as { startedAt?: unknown }).startedAt;
+    return {
+      kind: "held",
+      lock: { pid, startedAt: typeof startedAt === "string" ? startedAt : "" },
+    };
+  } catch {
+    return { kind: "corrupt" };
+  }
+}
+
+/**
+ * Take the listener lock if it is free, stale, or already ours.
+ *
+ * Returns false when another running process holds it. A lock naming a PID
+ * that is no longer running was left by a crashed window and is taken over;
+ * so is a corrupt one.
+ *
+ * The write uses exclusive create (`wx`) so two windows that read the same
+ * absent or stale lock at the same moment cannot both believe they own it:
+ * one create fails with EEXIST, and that window reads again to find the
+ * winner. Windows restored together on editor startup all reach this point
+ * within the same second, so that race is the common case, not a corner.
+ *
+ * Filesystem errors other than EEXIST propagate. The caller decides whether
+ * to listen without coordination when the storage directory is unwritable.
+ */
+export function tryAcquireLock(lockPath: string, options: AcquireOptions = {}): boolean {
+  const ownPid = options.ownPid ?? process.pid;
+  const isAlive = options.isAlive ?? isProcessAlive;
+  const now = options.now ?? (() => new Date());
+
+  // Two passes: the second is for a window that lost the exclusive create
+  // and needs to see who won.
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const state = readLock(lockPath);
+
+    if (state.kind === "held") {
+      if (state.lock.pid === ownPid) {
+        return true;
+      }
+      if (isAlive(state.lock.pid)) {
+        return false;
+      }
+    }
+
+    if (state.kind !== "absent") {
+      // Stale or corrupt: clear it so the exclusive create can succeed.
+      try {
+        unlinkSync(lockPath);
+      } catch {
+        // Another window may have removed it first. The create below
+        // settles who owns the replacement.
+      }
+    }
+
+    mkdirSync(path.dirname(lockPath), { recursive: true });
+
+    const lock: LockInfo = { pid: ownPid, startedAt: now().toISOString() };
+    try {
+      writeFileSync(lockPath, JSON.stringify(lock), { encoding: "utf8", flag: "wx" });
+      return true;
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "EEXIST") {
+        throw err;
+      }
+      // Lost the race. Loop once to read the winner.
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Remove the lock, but only if this process wrote it.
+ *
+ * Best effort throughout: a lock that cannot be removed is a stale lock, and
+ * the next window to look treats a dead PID as free.
+ */
+export function releaseLock(lockPath: string, ownPid: number = process.pid): void {
+  try {
+    const state = readLock(lockPath);
+    if (state.kind === "held" && state.lock.pid === ownPid) {
+      unlinkSync(lockPath);
+    }
+  } catch {
+    // Nothing to do. See above.
+  }
+}

--- a/src/sherpaEngine.ts
+++ b/src/sherpaEngine.ts
@@ -45,9 +45,16 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
    */
   private static readonly RELEASE_TIMEOUT_MS = 500;
 
+  /**
+   * `audioDevice` is the `wakeWord.audioDevice` setting: empty for the
+   * system default, otherwise a device index or a case-insensitive name
+   * substring. It is fixed for the life of the engine; the extension builds
+   * a new engine when the setting changes, as it does for `nodePath`.
+   */
   constructor(
     private readonly context: vscode.ExtensionContext,
-    private readonly nodePathOverride: string = ""
+    private readonly nodePathOverride: string = "",
+    private readonly audioDevice: string = ""
   ) {
     super();
   }
@@ -65,6 +72,10 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
       return;
     }
 
+    // A start supersedes any retry still scheduled from a crash. Left armed,
+    // it would fire into the fresh child below: a no-op if READY has arrived
+    // by then, otherwise a needless kill and respawn mid model load.
+    this.clearRetryTimer();
     this.forceKill();
 
     this._killedIntentionally = false;
@@ -109,6 +120,7 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
       threshold: safeThreshold,
       modelDir,
       debugMode,
+      audioDevice: this.audioDevice,
     };
     this.process.stdin?.write(JSON.stringify(config) + "\n");
 
@@ -223,18 +235,33 @@ export class SherpaEngine extends EventEmitter implements ISpeechEngine {
     this.clearRetryTimer();
     this.retryCount = 0;
 
+    // Kill whatever child exists before the state guard, for the same
+    // reason. A child that has been spawned but has not yet said READY is
+    // neither listening nor paused, and returning early left it to finish
+    // loading, open the microphone, and report READY to a stopped engine:
+    // Disable, Reset Consent, and an engine switch during that window all
+    // ended with the microphone open.
+    this.forceKill();
+
     if (!this._isListening && !this._isPaused) {
       return;
     }
 
     this._isPaused = false;
-    this.forceKill();
     this._isListening = false;
     this.emit("stopped");
   }
 
   pause(): void {
     if (!this._isListening) {
+      // Not listening, but a crash-backoff retry may still be armed. A pause
+      // must stop that retry reopening the microphone, and must leave the
+      // engine resumable, so it becomes a paused engine with no process.
+      if (this.retryTimer) {
+        this.clearRetryTimer();
+        this._isPaused = true;
+        this.emit("paused");
+      }
       return;
     }
 

--- a/src/wakeWordCore.ts
+++ b/src/wakeWordCore.ts
@@ -245,3 +245,72 @@ export function parsePowerShellError(raw: string): string {
   }
   return raw.replace(/#< CLIXML\s*/g, "").trim();
 }
+
+// -- Session statistics -------------------------------------------------
+
+/**
+ * Counters the extension host keeps for one listening session and writes to
+ * the output channel as a single line on deactivation. No telemetry, no
+ * network, no storage: the line exists so a user can see how the extension
+ * behaved over a day without reading the whole log.
+ */
+export interface SessionStats {
+  detections: number;
+  detectionsByPhrase: Map<string, number>;
+  errors: number;
+  engineStarts: number;
+  cooldowns: number;
+  /** Epoch milliseconds at which the counters were created. */
+  startedAt: number;
+}
+
+export function createSessionStats(startedAt: number = Date.now()): SessionStats {
+  return {
+    detections: 0,
+    detectionsByPhrase: new Map(),
+    errors: 0,
+    engineStarts: 0,
+    cooldowns: 0,
+    startedAt,
+  };
+}
+
+/** Count one accepted detection against its route label. */
+export function recordDetection(stats: SessionStats, label: string): void {
+  stats.detections++;
+  stats.detectionsByPhrase.set(label, (stats.detectionsByPhrase.get(label) ?? 0) + 1);
+}
+
+/** Whole minutes since the counters were created. Never negative. */
+export function sessionDurationMinutes(stats: SessionStats, now: number = Date.now()): number {
+  return Math.max(0, Math.round((now - stats.startedAt) / 60_000));
+}
+
+function plural(count: number, noun: string): string {
+  return `${count} ${noun}${count === 1 ? "" : "s"}`;
+}
+
+/**
+ * Render the session summary line:
+ *
+ *   Session: 342min, 14 detections (Claude: 8, Copilot: 4, Terminal: 2),
+ *   0 errors, 17 engine starts, 14 cooldowns
+ *
+ * Phrases are listed most-detected first, ties in the order first heard.
+ * The breakdown is omitted entirely when nothing was detected.
+ */
+export function formatSessionStats(stats: SessionStats, now: number = Date.now()): string {
+  const breakdown = Array.from(stats.detectionsByPhrase.entries())
+    .sort((a, b) => b[1] - a[1])
+    .map(([label, count]) => `${label}: ${count}`)
+    .join(", ");
+
+  return (
+    `Session: ${sessionDurationMinutes(stats, now)}min, ` +
+    plural(stats.detections, "detection") +
+    (breakdown ? ` (${breakdown})` : "") +
+    `, ${plural(stats.errors, "error")}` +
+    `, ${plural(stats.engineStarts, "engine start")}` +
+    `, ${plural(stats.cooldowns, "cooldown")}`
+  );
+}

--- a/src/windowsSpeechEngine.ts
+++ b/src/windowsSpeechEngine.ts
@@ -46,6 +46,11 @@ export class WindowsSpeechEngine extends EventEmitter implements ISpeechEngine {
       return;
     }
 
+    // A start supersedes any retry still scheduled from a crash. Left armed,
+    // it would fire into the fresh process below: a no-op if READY has
+    // arrived by then, otherwise a needless kill and respawn.
+    this.clearRetryTimer();
+
     // Clean up any orphaned process from a previous session
     this.killProcess();
 
@@ -172,18 +177,31 @@ export class WindowsSpeechEngine extends EventEmitter implements ISpeechEngine {
     this.clearRetryTimer();
     this.retryCount = 0;
 
+    // Kill whatever process exists before the state guard, for the same
+    // reason. A process that has been spawned but has not yet said READY is
+    // neither listening nor paused, and returning early left it to finish
+    // loading, open the microphone, and report READY to a stopped engine.
+    this.killProcess();
+
     if (!this._isListening && !this._isPaused) {
       return;
     }
 
     this._isPaused = false;
-    this.killProcess();
     this._isListening = false;
     this.emit("stopped");
   }
 
   pause(): void {
     if (!this._isListening) {
+      // Not listening, but a crash-backoff retry may still be armed. A pause
+      // must stop that retry reopening the microphone, and must leave the
+      // engine resumable, so it becomes a paused engine with no process.
+      if (this.retryTimer) {
+        this.clearRetryTimer();
+        this._isPaused = true;
+        this.emit("paused");
+      }
       return;
     }
 

--- a/tests/engine/configParsing.test.js
+++ b/tests/engine/configParsing.test.js
@@ -3,6 +3,8 @@ import {
   clampKeywordThreshold,
   drainLines,
   parseControlLine,
+  resolveAudioDevice,
+  withAudioDevice,
 } from '../../engine/lib/control.js';
 
 /**
@@ -105,6 +107,128 @@ describe('parseControlLine', () => {
     expect(result.config.phrases).toBeUndefined();
     expect(result.config.threshold).toBeUndefined();
     expect(result.config.modelDir).toBeUndefined();
+    expect(result.config.audioDevice).toBeUndefined();
+  });
+
+  it('passes audioDevice through from the config line as sent', () => {
+    const line = JSON.stringify({
+      phrases: [{ phrase: 'hey claude', label: 'Claude' }],
+      threshold: 0.3,
+      modelDir: 'x',
+      debugMode: false,
+      audioDevice: 'Blue Yeti',
+    });
+    expect(parseControlLine(line).config.audioDevice).toBe('Blue Yeti');
+  });
+
+  it('passes a numeric-string audioDevice through untouched', () => {
+    // Index resolution is resolveAudioDevice's job, not the parser's.
+    const line = JSON.stringify({ audioDevice: '1' });
+    expect(parseControlLine(line).config.audioDevice).toBe('1');
+  });
+});
+
+/**
+ * wakeWord.audioDevice is a string setting; decibri's `device` option is a
+ * number (index) or a string (case-insensitive name substring).
+ */
+describe('resolveAudioDevice', () => {
+  it('means the system default when empty or blank', () => {
+    expect(resolveAudioDevice('')).toBeUndefined();
+    expect(resolveAudioDevice('   ')).toBeUndefined();
+    expect(resolveAudioDevice('\t\n')).toBeUndefined();
+  });
+
+  it('means the system default when absent or not a string', () => {
+    expect(resolveAudioDevice(undefined)).toBeUndefined();
+    expect(resolveAudioDevice(null)).toBeUndefined();
+    expect(resolveAudioDevice(false)).toBeUndefined();
+    expect(resolveAudioDevice({})).toBeUndefined();
+    expect(resolveAudioDevice([])).toBeUndefined();
+  });
+
+  it('passes a name substring through as a string', () => {
+    expect(resolveAudioDevice('USB')).toBe('USB');
+    expect(resolveAudioDevice('Blue Yeti')).toBe('Blue Yeti');
+  });
+
+  it('keeps the case as typed and leaves the matching to decibri', () => {
+    expect(resolveAudioDevice('usb')).toBe('usb');
+  });
+
+  it('trims surrounding whitespace from a name', () => {
+    expect(resolveAudioDevice('  Blue Yeti  ')).toBe('Blue Yeti');
+  });
+
+  it('parses a digit-only string as a device index', () => {
+    expect(resolveAudioDevice('0')).toBe(0);
+    expect(resolveAudioDevice('1')).toBe(1);
+    expect(resolveAudioDevice(' 12 ')).toBe(12);
+  });
+
+  it('does not read a name that merely starts with digits as an index', () => {
+    // parseInt would turn "2nd mic" into index 2 and open the wrong device.
+    expect(resolveAudioDevice('2nd mic')).toBe('2nd mic');
+    expect(resolveAudioDevice('1 USB')).toBe('1 USB');
+    expect(resolveAudioDevice('3.5mm jack')).toBe('3.5mm jack');
+  });
+
+  it('accepts a non-negative integer that arrived as a number', () => {
+    // settings.json is not schema-validated, so a bare number can reach the
+    // child if the extension ever stops coercing it.
+    expect(resolveAudioDevice(0)).toBe(0);
+    expect(resolveAudioDevice(2)).toBe(2);
+  });
+
+  it('rejects a negative, fractional, or non-finite number', () => {
+    expect(resolveAudioDevice(-1)).toBeUndefined();
+    expect(resolveAudioDevice(1.5)).toBeUndefined();
+    expect(resolveAudioDevice(NaN)).toBeUndefined();
+    expect(resolveAudioDevice(Infinity)).toBeUndefined();
+  });
+});
+
+describe('withAudioDevice', () => {
+  const base = Object.freeze({
+    sampleRate: 16000,
+    channels: 1,
+    vad: 'silero',
+    dcRemoval: true,
+    highpass: 80,
+    agc: -18,
+  });
+
+  it('omits the device key entirely when no device is configured', () => {
+    for (const none of ['', '   ', undefined, null]) {
+      const options = withAudioDevice(base, none);
+      expect(options).toEqual(base);
+      expect('device' in options).toBe(false);
+    }
+  });
+
+  it('adds a name substring as device', () => {
+    expect(withAudioDevice(base, 'USB')).toEqual({ ...base, device: 'USB' });
+  });
+
+  it('adds a digit-only string as a numeric index', () => {
+    expect(withAudioDevice(base, '1')).toEqual({ ...base, device: 1 });
+  });
+
+  it('keeps the conditioning chain intact alongside the device', () => {
+    const options = withAudioDevice(base, 'Blue Yeti');
+    expect(options.vad).toBe('silero');
+    expect(options.dcRemoval).toBe(true);
+    expect(options.highpass).toBe(80);
+    expect(options.agc).toBe(-18);
+    expect(options.sampleRate).toBe(16000);
+    expect(options.channels).toBe(1);
+  });
+
+  it('does not mutate the options it was given', () => {
+    const input = { ...base };
+    withAudioDevice(input, 'USB');
+    expect(input).toEqual(base);
+    expect('device' in input).toBe(false);
   });
 });
 

--- a/tests/engine/micErrors.test.js
+++ b/tests/engine/micErrors.test.js
@@ -68,3 +68,87 @@ describe('micErrorMessage', () => {
     }
   });
 });
+
+/**
+ * With wakeWord.audioDevice set, a lookup failure has to name the setting and
+ * the value. "No microphone found" is the wrong diagnosis on a machine with
+ * three microphones where the name simply matched none of them.
+ */
+describe('micErrorMessage with a configured device', () => {
+  const notFound = { code: 'MICROPHONE_NOT_FOUND', message: 'No microphone found matching "Blue Yeti"' };
+
+  it('names the device that matched nothing', () => {
+    expect(micErrorMessage(notFound, 'Failed to open microphone', 'Blue Yeti')).toBe(
+      'No microphone matching "Blue Yeti" was found. ' +
+        'Check wakeWord.audioDevice against the input devices on this machine.'
+    );
+  });
+
+  it('keeps the generic message when no device was configured', () => {
+    const generic = 'No microphone found. Check your audio device settings.';
+    expect(micErrorMessage(notFound, 'prefix')).toBe(generic);
+    expect(micErrorMessage(notFound, 'prefix', '')).toBe(generic);
+    expect(micErrorMessage(notFound, 'prefix', '   ')).toBe(generic);
+    expect(micErrorMessage(notFound, 'prefix', null)).toBe(generic);
+  });
+
+  it('names an index that is past the end of the device list', () => {
+    // decibri's JS wrapper raises a plain RangeError here, with no code.
+    const err = new RangeError(
+      'device index out of range. Call Microphone.devices() to list available devices'
+    );
+    expect(micErrorMessage(err, 'Failed to open microphone', '7')).toBe(
+      'Microphone index 7 is out of range. ' +
+        'Check wakeWord.audioDevice against the input devices on this machine.'
+    );
+  });
+
+  it('falls back to the prefix for an out-of-range index when no device was configured', () => {
+    const err = new RangeError('device index out of range. Call Microphone.devices()');
+    expect(micErrorMessage(err, 'Failed to open microphone')).toBe(
+      'Failed to open microphone: device index out of range. Call Microphone.devices()'
+    );
+  });
+
+  it('explains a name that matches more than one device', () => {
+    expect(micErrorMessage({ code: 'MULTIPLE_DEVICES_MATCH' }, 'prefix', 'Mic')).toBe(
+      'More than one microphone matches "Mic". ' +
+        'Use a longer name or the device index in wakeWord.audioDevice.'
+    );
+  });
+
+  it('still explains an ambiguous match with no device recorded', () => {
+    expect(micErrorMessage({ code: 'MULTIPLE_DEVICES_MATCH' }, 'prefix')).toContain(
+      'the requested name'
+    );
+  });
+
+  it('names a device that is not an input', () => {
+    expect(micErrorMessage({ code: 'NOT_AN_INPUT_DEVICE' }, 'prefix', 'Speakers')).toBe(
+      'The audio device "Speakers" is not a microphone. Check wakeWord.audioDevice.'
+    );
+  });
+
+  it('does not blame the device for a machine with no microphone at all', () => {
+    expect(micErrorMessage({ code: 'NO_MICROPHONE_FOUND' }, 'prefix', 'USB')).toBe(
+      'No microphone found. Check your audio device settings.'
+    );
+  });
+
+  it('ignores the device for errors unrelated to selection', () => {
+    expect(micErrorMessage({ code: 'PERMISSION_DENIED' }, 'prefix', 'USB')).toBe(
+      'Microphone access denied. Enable microphone access for VS Code in your system privacy settings.'
+    );
+    expect(
+      micErrorMessage({ code: 'DEVICE_FAILED', message: 'stream closed' }, 'prefix', 'USB')
+    ).toBe('The microphone stopped responding: stream closed');
+    expect(micErrorMessage({ code: 'SOMETHING_NEW', message: 'boom' }, 'prefix', 'USB')).toBe(
+      'prefix: boom'
+    );
+  });
+
+  it('trims and stringifies whatever the setting held', () => {
+    expect(micErrorMessage(notFound, 'prefix', '  Blue Yeti ')).toContain('"Blue Yeti"');
+    expect(micErrorMessage(notFound, 'prefix', 1)).toContain('"1"');
+  });
+});

--- a/tests/mocks/childProcess.ts
+++ b/tests/mocks/childProcess.ts
@@ -1,0 +1,90 @@
+import { EventEmitter } from "events";
+
+/**
+ * Stand-in for the ChildProcess that `child_process.spawn()` returns, so the
+ * engine state machines can be driven without a real process.
+ *
+ * The streams are plain EventEmitters rather than Node Readable/Writable
+ * instances. The engines only ever call on(), once(), removeAllListeners(),
+ * write(), end(), and read `writable`, and a synchronous 'data' emission lets
+ * a test say exactly when a line arrives instead of waiting on stream
+ * internals. Tests mock `spawn` to hand one of these back and then drive it:
+ * `sendLine("READY")`, `simulateExit(1)`, and so on.
+ */
+export class MockWritable extends EventEmitter {
+  writable = true;
+  /** Everything written, in order, as strings. */
+  readonly chunks: string[] = [];
+
+  write(chunk: string | Buffer): boolean {
+    if (!this.writable) {
+      // Node reports a write after end as an 'error' event, not a throw.
+      this.emit("error", new Error("write after end"));
+      return false;
+    }
+    this.chunks.push(chunk.toString());
+    return true;
+  }
+
+  end(): void {
+    this.writable = false;
+  }
+}
+
+export class MockReadable extends EventEmitter {
+  push(chunk: string | Buffer): void {
+    this.emit("data", Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+}
+
+export class MockChildProcess extends EventEmitter {
+  readonly stdin = new MockWritable();
+  readonly stdout = new MockReadable();
+  readonly stderr = new MockReadable();
+  readonly pid: number;
+  killed = false;
+  exitCode: number | null = null;
+
+  constructor(pid = 4242) {
+    super();
+    this.pid = pid;
+  }
+
+  kill(): boolean {
+    this.killed = true;
+    return true;
+  }
+
+  /** The child prints one complete protocol line. */
+  sendLine(line: string): void {
+    this.stdout.push(line + "\n");
+  }
+
+  /** The child prints an arbitrary chunk: part of a line, or several lines. */
+  sendRaw(text: string): void {
+    this.stdout.push(text);
+  }
+
+  sendStderr(text: string): void {
+    this.stderr.push(text);
+  }
+
+  /** The child exits. `code` is null when it died from a signal. */
+  simulateExit(code: number | null, signal: NodeJS.Signals | null = null): void {
+    this.exitCode = code;
+    this.emit("exit", code, signal);
+  }
+
+  /** spawn() itself failed, for example ENOENT for the node executable. */
+  simulateError(err: Error): void {
+    this.emit("error", err);
+  }
+
+  /** Every complete line written to stdin so far. */
+  get stdinLines(): string[] {
+    return this.stdin.chunks
+      .join("")
+      .split("\n")
+      .filter((line) => line.length > 0);
+  }
+}

--- a/tests/unit/engineLifecycle.test.ts
+++ b/tests/unit/engineLifecycle.test.ts
@@ -1,0 +1,778 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type * as vscode from "vscode";
+import { MockChildProcess } from "../mocks/childProcess";
+
+/**
+ * Engine lifecycle under a mock child process.
+ *
+ * These are the paths that were only ever checked by hand: start, stop,
+ * pause, resume, the crash and retry backoff, the retry-timer cancellation
+ * that stop() and pause() must perform (the D2 fix), and the RELEASED
+ * handshake with its timeout. `spawn` is replaced with a factory for
+ * MockChildProcess, `fs` says the model is already downloaded, and the timers
+ * are faked so a ten second backoff costs nothing.
+ *
+ * setImmediate is left real on purpose: `start()` is async because of the
+ * model check, and one real macrotask turn is the simplest way to let its
+ * promise chain settle after a faked timer has fired.
+ */
+
+const mocks = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  execSync: vi.fn(),
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock("child_process", () => ({
+  spawn: mocks.spawn,
+  execSync: mocks.execSync,
+}));
+
+vi.mock("fs", () => ({
+  existsSync: mocks.existsSync,
+  readFileSync: mocks.readFileSync,
+  mkdirSync: vi.fn(),
+  createWriteStream: vi.fn(),
+  writeFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+import { SherpaEngine } from "../../src/sherpaEngine";
+import { WakePhrase } from "../../src/speechEngineInterface";
+
+const ROUTES: WakePhrase[] = [
+  { label: "Claude", phrase: "hey claude", command: "claude-vscode.focus" },
+  {
+    label: "Terminal",
+    phrase: ["hey computer", "open terminal"],
+    command: "workbench.action.terminal.focus",
+    cooldownSeconds: 10,
+  },
+];
+
+const NODE = "/fake/bin/node";
+const RELEASE_TIMEOUT_MS = 500;
+const RETRY_DELAYS_MS = [2000, 5000, 10000];
+
+let spawned: MockChildProcess[] = [];
+
+function latest(): MockChildProcess {
+  const proc = spawned[spawned.length - 1];
+  if (!proc) {
+    throw new Error("nothing has been spawned");
+  }
+  return proc;
+}
+
+interface Captured {
+  started: number;
+  stopped: number;
+  paused: number;
+  detected: Array<{ phrase: WakePhrase; confidence: number | undefined }>;
+  warnings: string[];
+  errors: Error[];
+  debug: string[];
+}
+
+/** Subscribe to everything. An unhandled 'error' would throw inside the engine. */
+function capture(engine: SherpaEngine): Captured {
+  const c: Captured = {
+    started: 0,
+    stopped: 0,
+    paused: 0,
+    detected: [],
+    warnings: [],
+    errors: [],
+    debug: [],
+  };
+  engine.on("started", () => c.started++);
+  engine.on("stopped", () => c.stopped++);
+  engine.on("paused", () => c.paused++);
+  engine.on("detected", (phrase, confidence) => c.detected.push({ phrase, confidence }));
+  engine.on("warning", (msg) => c.warnings.push(msg));
+  engine.on("error", (err) => c.errors.push(err));
+  engine.on("debug", (info) => c.debug.push(info));
+  return c;
+}
+
+function makeEngine(audioDevice = ""): { engine: SherpaEngine; events: Captured } {
+  const context = {
+    globalStorageUri: { fsPath: "/fake/storage" },
+  } as unknown as vscode.ExtensionContext;
+  const engine = new SherpaEngine(context, NODE, audioDevice);
+  return { engine, events: capture(engine) };
+}
+
+/** One real macrotask turn: lets start()'s promise chain settle. */
+function flush(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+async function startAndReady(engine: SherpaEngine): Promise<MockChildProcess> {
+  await engine.start(ROUTES, 0.3, false);
+  const proc = latest();
+  proc.sendLine("READY");
+  return proc;
+}
+
+/** Crash the current child and let the retry timer fire, if one is armed. */
+async function crashAndRetry(delayMs: number): Promise<void> {
+  latest().simulateExit(1);
+  await vi.advanceTimersByTimeAsync(delayMs);
+  await flush();
+}
+
+function configLine(proc: MockChildProcess): Record<string, unknown> {
+  return JSON.parse(proc.stdinLines[0]);
+}
+
+beforeEach(() => {
+  spawned = [];
+  mocks.spawn.mockReset();
+  mocks.spawn.mockImplementation(() => {
+    const proc = new MockChildProcess(1000 + spawned.length);
+    spawned.push(proc);
+    return proc;
+  });
+  mocks.execSync.mockReset();
+  // The model is already on disk: every file exists and the version matches.
+  mocks.existsSync.mockReset();
+  mocks.existsSync.mockReturnValue(true);
+  mocks.readFileSync.mockReset();
+  mocks.readFileSync.mockReturnValue("1");
+  vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout", "setInterval", "clearInterval"] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ── start ───────────────────────────────────────────────────
+
+describe("start", () => {
+  it("spawns the engine script under the configured node executable", async () => {
+    const { engine } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+    const [command, args, options] = mocks.spawn.mock.calls[0];
+    expect(command).toBe(NODE);
+    expect(args).toHaveLength(1);
+    expect(args[0]).toMatch(/audio-engine\.js$/);
+    expect(options).toEqual({ stdio: ["pipe", "pipe", "pipe"] });
+    expect(mocks.execSync).not.toHaveBeenCalled();
+  });
+
+  it("sends the config as one JSON line on stdin and keeps stdin open", async () => {
+    const { engine } = makeEngine();
+    await engine.start(ROUTES, 0.3, true);
+    const proc = latest();
+    expect(proc.stdinLines).toHaveLength(1);
+    const config = configLine(proc);
+    // Only phrase and label cross the boundary: the child never sees a
+    // command ID or a cooldown.
+    expect(config.phrases).toEqual([
+      { phrase: "hey claude", label: "Claude" },
+      { phrase: ["hey computer", "open terminal"], label: "Terminal" },
+    ]);
+    expect(config.threshold).toBe(0.3);
+    expect(config.modelDir).toMatch(/sherpa-onnx/);
+    expect(config.debugMode).toBe(true);
+    expect(proc.stdin.writable).toBe(true);
+  });
+
+  it("sends an empty audioDevice by default", async () => {
+    const { engine } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    expect(configLine(latest()).audioDevice).toBe("");
+  });
+
+  it("passes the configured audio device to the child", async () => {
+    const { engine } = makeEngine("Blue Yeti");
+    await engine.start(ROUTES, 0.3, false);
+    expect(configLine(latest()).audioDevice).toBe("Blue Yeti");
+  });
+
+  it("clamps the threshold before sending it", async () => {
+    const { engine } = makeEngine();
+    await engine.start(ROUTES, 5, false);
+    expect(configLine(latest()).threshold).toBe(0.9);
+  });
+
+  it("is not listening until the child reports READY", async () => {
+    const { engine, events } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    expect(engine.isListening).toBe(false);
+    expect(events.started).toBe(0);
+
+    latest().sendLine("READY");
+    expect(engine.isListening).toBe(true);
+    expect(engine.isPaused).toBe(false);
+    expect(events.started).toBe(1);
+  });
+
+  it("is a no-op while already listening", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    await engine.start(ROUTES, 0.3, false);
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+    expect(events.started).toBe(1);
+    expect(latest().killed).toBe(false);
+  });
+
+  it("replaces a child that has not yet reported READY", async () => {
+    const { engine } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    const first = latest();
+    await engine.start(ROUTES, 0.3, false);
+    expect(first.killed).toBe(true);
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it("reports a missing node executable as a nodePath problem", async () => {
+    const { engine, events } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    latest().simulateError(new Error("spawn /fake/bin/node ENOENT"));
+    expect(events.errors).toHaveLength(1);
+    expect(events.errors[0].message).toMatch(/wakeWord\.nodePath/);
+    expect(engine.isListening).toBe(false);
+  });
+
+  it("reports any other spawn failure with its message", async () => {
+    const { engine, events } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    latest().simulateError(new Error("EACCES"));
+    expect(events.errors[0].message).toBe("Failed to start audio engine: EACCES");
+  });
+
+  it("reports the model being unavailable without spawning", async () => {
+    // Model files missing and the download path is not something a unit
+    // test can exercise, so ensureModel's failure surfaces as an error.
+    mocks.existsSync.mockReturnValue(false);
+    const { engine, events } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    expect(mocks.spawn).not.toHaveBeenCalled();
+    expect(events.errors).toHaveLength(1);
+    expect(events.errors[0].message).toMatch(/^Model unavailable: /);
+  });
+});
+
+// ── stdout protocol ─────────────────────────────────────────
+
+describe("stdout protocol", () => {
+  it("emits a detection for a configured phrase, with no confidence", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().sendLine("DETECTED:hey claude");
+    expect(events.detected).toHaveLength(1);
+    expect(events.detected[0].phrase.label).toBe("Claude");
+    expect(events.detected[0].confidence).toBeUndefined();
+  });
+
+  it("matches a phrase alias", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().sendLine("DETECTED:open terminal");
+    expect(events.detected[0].phrase.label).toBe("Terminal");
+  });
+
+  it("ignores a phrase that is not configured", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().sendLine("DETECTED:hello world");
+    expect(events.detected).toHaveLength(0);
+  });
+
+  it("reassembles lines split across chunks", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    const proc = latest();
+    proc.sendRaw("DETEC");
+    proc.sendRaw("TED:hey claude\nDEB");
+    expect(events.detected).toHaveLength(1);
+    proc.sendRaw("UG:half a line\n");
+    expect(events.debug).toContain("half a line");
+  });
+
+  it("handles several lines in one chunk", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().sendRaw("DETECTED:hey claude\nDETECTED:hey computer\n");
+    expect(events.detected.map((d) => d.phrase.label)).toEqual(["Claude", "Terminal"]);
+  });
+
+  it("forwards ERROR lines as error events", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().sendLine("ERROR:Failed to open microphone: boom");
+    expect(events.errors[0].message).toBe("Failed to open microphone: boom");
+  });
+
+  it("forwards DEBUG lines and stderr as debug events", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().sendLine("DEBUG:VAD: speech");
+    latest().sendStderr("  warning from a dependency \n");
+    expect(events.debug).toContain("VAD: speech");
+    expect(events.debug).toContain("stderr: warning from a dependency");
+  });
+
+  it("ignores output that is not part of the protocol", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().sendLine("");
+    latest().sendLine("some stray console.log");
+    expect(events.detected).toHaveLength(0);
+    expect(events.errors).toHaveLength(0);
+    expect(engine.isListening).toBe(true);
+  });
+});
+
+// ── stop ────────────────────────────────────────────────────
+
+describe("stop", () => {
+  it("asks the child to release, closes stdin, kills it, and reports stopped", async () => {
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.stop();
+    expect(engine.isListening).toBe(false);
+    expect(engine.isPaused).toBe(false);
+    expect(events.stopped).toBe(1);
+    expect(proc.stdinLines).toContain("stop");
+    expect(proc.stdin.writable).toBe(false);
+    expect(proc.killed).toBe(true);
+  });
+
+  it("is a no-op when nothing is running", () => {
+    const { engine, events } = makeEngine();
+    expect(() => engine.stop()).not.toThrow();
+    expect(events.stopped).toBe(0);
+  });
+
+  it("does not treat the exit of a child it killed as a crash", async () => {
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.stop();
+    proc.simulateExit(1);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS_MS[0]);
+    await flush();
+    expect(events.warnings).toHaveLength(0);
+    expect(events.errors).toHaveLength(0);
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("kills a child that has not yet reported READY", async () => {
+    // Nothing was listening, so there is no transition to report, but the
+    // child must not be left to finish starting: before this was fixed a
+    // Disable during the model load ended with the microphone open.
+    const { engine, events } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    const proc = latest();
+    engine.stop();
+    expect(proc.killed).toBe(true);
+    expect(proc.stdin.writable).toBe(false);
+    expect(events.stopped).toBe(0);
+  });
+
+  it("ignores a READY from a child it killed before READY", async () => {
+    const { engine, events } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    const proc = latest();
+    engine.stop();
+    proc.sendLine("READY");
+    expect(engine.isListening).toBe(false);
+    expect(events.started).toBe(0);
+  });
+});
+
+// ── pause and the RELEASED protocol ─────────────────────────
+
+describe("pause and the RELEASED handshake", () => {
+  it("sends stop on stdin and reports paused while the release is in flight", async () => {
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.pause();
+    expect(engine.isPaused).toBe(true);
+    expect(engine.isListening).toBe(false);
+    expect(events.paused).toBe(1);
+    expect(proc.stdinLines).toContain("stop");
+    // Not killed yet: the child gets a chance to close the device itself.
+    expect(proc.killed).toBe(false);
+  });
+
+  it("kills the child once RELEASED arrives", async () => {
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.pause();
+    proc.sendLine("RELEASED");
+    expect(proc.killed).toBe(true);
+    expect(events.debug).toContain("Mic release: acknowledged by engine");
+  });
+
+  it("force-kills the child when no RELEASED arrives within the timeout", async () => {
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.pause();
+    await vi.advanceTimersByTimeAsync(RELEASE_TIMEOUT_MS - 1);
+    expect(proc.killed).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(proc.killed).toBe(true);
+    expect(events.debug).toContain(
+      `Mic release: no acknowledgement after ${RELEASE_TIMEOUT_MS}ms, forcing`
+    );
+  });
+
+  it("does not force-kill a second time after an acknowledged release", async () => {
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.pause();
+    proc.sendLine("RELEASED");
+    await vi.advanceTimersByTimeAsync(RELEASE_TIMEOUT_MS * 2);
+    expect(events.debug.filter((d) => d.startsWith("Mic release:"))).toHaveLength(1);
+  });
+
+  it("does not emit a detection from a child that is being released", async () => {
+    // The extension's own guard against repeats is shouldDebounce(), tested
+    // in debounce.test.ts. This is the engine's half: once pause() has
+    // asked for the microphone back, nothing the child still prints counts.
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.pause();
+    proc.sendLine("DETECTED:hey claude");
+    expect(events.detected).toHaveLength(0);
+  });
+
+  it("does not report stopped when the released child exits", async () => {
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.pause();
+    proc.sendLine("RELEASED");
+    proc.simulateExit(0);
+    expect(events.stopped).toBe(0);
+    expect(engine.isPaused).toBe(true);
+  });
+
+  it("force-kills at once when stdin is already closed", async () => {
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    proc.stdin.end();
+    engine.pause();
+    expect(proc.killed).toBe(true);
+    expect(events.debug).toContain("Mic release: stdin already closed");
+  });
+
+  it("is a no-op when nothing is listening and no retry is pending", () => {
+    const { engine, events } = makeEngine();
+    engine.pause();
+    expect(engine.isPaused).toBe(false);
+    expect(events.paused).toBe(0);
+  });
+
+  it("lets stop() cut a release short", async () => {
+    const { engine, events } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.pause();
+    engine.stop();
+    expect(proc.killed).toBe(true);
+    expect(engine.isPaused).toBe(false);
+    expect(events.stopped).toBe(1);
+    // The release timer was cleared with the kill, so nothing fires later.
+    await vi.advanceTimersByTimeAsync(RELEASE_TIMEOUT_MS);
+    expect(events.debug.filter((d) => d.startsWith("Mic release:"))).toHaveLength(0);
+  });
+});
+
+// ── resume ──────────────────────────────────────────────────
+
+describe("resume", () => {
+  it("starts a fresh child after a pause", async () => {
+    const { engine, events } = makeEngine();
+    const first = await startAndReady(engine);
+    engine.pause();
+    first.sendLine("RELEASED");
+
+    engine.resume();
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+    expect(latest()).not.toBe(first);
+
+    latest().sendLine("READY");
+    expect(engine.isListening).toBe(true);
+    expect(engine.isPaused).toBe(false);
+    expect(events.started).toBe(2);
+  });
+
+  it("remains paused until the new child reports READY", async () => {
+    const { engine } = makeEngine();
+    const first = await startAndReady(engine);
+    engine.pause();
+    first.sendLine("RELEASED");
+    engine.resume();
+    await flush();
+    expect(engine.isPaused).toBe(true);
+    expect(engine.isListening).toBe(false);
+  });
+
+  it("gives the new child the same phrases and threshold", async () => {
+    const { engine } = makeEngine();
+    const first = await startAndReady(engine);
+    engine.pause();
+    first.sendLine("RELEASED");
+    engine.resume();
+    await flush();
+    expect(configLine(latest())).toEqual(configLine(first));
+  });
+
+  it("is a no-op unless paused", async () => {
+    const { engine } = makeEngine();
+    engine.resume();
+    await flush();
+    expect(mocks.spawn).not.toHaveBeenCalled();
+
+    await startAndReady(engine);
+    engine.resume();
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── crash and retry ─────────────────────────────────────────
+
+describe("crash and retry", () => {
+  it("warns and retries after the first backoff delay", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().simulateExit(1);
+
+    expect(engine.isListening).toBe(false);
+    expect(events.warnings).toHaveLength(1);
+    expect(events.warnings[0]).toMatch(/exit code 1\. Retrying in 2s \(attempt 1\/3\)/);
+    expect(events.errors).toHaveLength(0);
+
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS_MS[0] - 1);
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it("escalates the delay on each consecutive crash", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    await crashAndRetry(RETRY_DELAYS_MS[0]);
+    await crashAndRetry(RETRY_DELAYS_MS[1]);
+    await crashAndRetry(RETRY_DELAYS_MS[2]);
+    expect(events.warnings.map((w) => w.match(/Retrying in (\d+)s \(attempt (\d)\/3\)/)?.slice(1))).toEqual([
+      ["2", "1"],
+      ["5", "2"],
+      ["10", "3"],
+    ]);
+    expect(mocks.spawn).toHaveBeenCalledTimes(4);
+  });
+
+  it("gives up with an error after three retries", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    await crashAndRetry(RETRY_DELAYS_MS[0]);
+    await crashAndRetry(RETRY_DELAYS_MS[1]);
+    await crashAndRetry(RETRY_DELAYS_MS[2]);
+    latest().simulateExit(1);
+
+    expect(events.errors).toHaveLength(1);
+    expect(events.errors[0].message).toBe("exit code 1 (failed after 3 retries)");
+    expect(events.warnings).toHaveLength(3);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(4);
+    expect(engine.isListening).toBe(false);
+  });
+
+  it("resets the retry budget once a child reports READY", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    await crashAndRetry(RETRY_DELAYS_MS[0]);
+    latest().sendLine("READY");
+    expect(engine.isListening).toBe(true);
+
+    latest().simulateExit(1);
+    expect(events.warnings[1]).toMatch(/Retrying in 2s \(attempt 1\/3\)/);
+  });
+
+  it("treats a clean exit while listening as a stop, not a crash", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().simulateExit(0);
+    expect(events.stopped).toBe(1);
+    expect(events.warnings).toHaveLength(0);
+    expect(engine.isListening).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a crash that happens before READY", async () => {
+    const { engine, events } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    latest().simulateExit(1);
+    expect(events.warnings).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(RETRY_DELAYS_MS[0]);
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── the D2 fix: nothing may restart the microphone after stop() ──
+
+describe("stop during crash backoff", () => {
+  it("cancels the pending retry so nothing reopens the microphone", async () => {
+    const { engine } = makeEngine();
+    await startAndReady(engine);
+    latest().simulateExit(1);
+
+    engine.stop();
+    expect(engine.isListening).toBe(false);
+    expect(engine.isPaused).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report a phantom stop for an engine that was not running", async () => {
+    // The crash already took the engine out of the listening state. The
+    // extension sets its own status bar on Disable, so no event is owed.
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().simulateExit(1);
+    engine.stop();
+    expect(events.stopped).toBe(0);
+  });
+
+  it("leaves the engine startable with a fresh retry budget", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    await crashAndRetry(RETRY_DELAYS_MS[0]);
+    latest().simulateExit(1);
+    expect(events.warnings[1]).toMatch(/attempt 2\/3/);
+
+    engine.stop();
+    await engine.start(ROUTES, 0.3, false);
+    latest().sendLine("READY");
+    expect(engine.isListening).toBe(true);
+
+    latest().simulateExit(1);
+    expect(events.warnings[2]).toMatch(/attempt 1\/3/);
+  });
+});
+
+describe("pause during crash backoff", () => {
+  it("cancels the pending retry and leaves the engine paused", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().simulateExit(1);
+
+    engine.pause();
+    expect(engine.isPaused).toBe(true);
+    expect(engine.isListening).toBe(false);
+    expect(events.paused).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("can be resumed, which starts a fresh child", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().simulateExit(1);
+    engine.pause();
+
+    engine.resume();
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+    latest().sendLine("READY");
+    expect(engine.isListening).toBe(true);
+    expect(events.started).toBe(2);
+  });
+
+  it("can be stopped, which reports stopped and clears the pause", async () => {
+    const { engine, events } = makeEngine();
+    await startAndReady(engine);
+    latest().simulateExit(1);
+    engine.pause();
+
+    engine.stop();
+    expect(engine.isPaused).toBe(false);
+    expect(events.stopped).toBe(1);
+  });
+});
+
+describe("start during crash backoff", () => {
+  it("supersedes the pending retry rather than stacking a second start", async () => {
+    const { engine } = makeEngine();
+    await startAndReady(engine);
+    latest().simulateExit(1);
+
+    await engine.start(ROUTES, 0.3, false);
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+    const manual = latest();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+    expect(manual.killed).toBe(false);
+  });
+});
+
+// ── dispose ─────────────────────────────────────────────────
+
+describe("dispose", () => {
+  it("kills the child and drops every listener", async () => {
+    const { engine } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.dispose();
+    expect(proc.killed).toBe(true);
+    expect(engine.isListening).toBe(false);
+    for (const event of ["detected", "started", "stopped", "paused", "error", "warning", "debug"]) {
+      expect(engine.listenerCount(event)).toBe(0);
+    }
+  });
+
+  it("cancels a pending retry", async () => {
+    const { engine } = makeEngine();
+    await startAndReady(engine);
+    latest().simulateExit(1);
+    engine.dispose();
+    await vi.advanceTimersByTimeAsync(60_000);
+    await flush();
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("cancels an in-flight release and kills the child now", async () => {
+    const { engine } = makeEngine();
+    const proc = await startAndReady(engine);
+    engine.pause();
+    engine.dispose();
+    expect(proc.killed).toBe(true);
+    // The release timer is gone with the listeners: nothing left to fire.
+    expect(vi.getTimerCount()).toBe(0);
+    await vi.advanceTimersByTimeAsync(RELEASE_TIMEOUT_MS);
+  });
+
+  it("kills a child that has not yet reported READY", async () => {
+    // An engine switch during the model load disposes the old engine. The
+    // old child must die with it rather than open the microphone next to
+    // the new engine's child.
+    const { engine } = makeEngine();
+    await engine.start(ROUTES, 0.3, false);
+    const proc = latest();
+    engine.dispose();
+    expect(proc.killed).toBe(true);
+    proc.sendLine("READY");
+    expect(engine.isListening).toBe(false);
+  });
+});

--- a/tests/unit/lockFile.test.ts
+++ b/tests/unit/lockFile.test.ts
@@ -1,0 +1,390 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * In-memory stand-in for the handful of fs calls the lock module makes.
+ *
+ * It honours the `wx` (exclusive create) flag, which is what makes lock
+ * acquisition atomic between two windows, so the race path can be driven
+ * deterministically rather than hoped for.
+ */
+const fsMock = vi.hoisted(() => {
+  const files = new Map<string, string>();
+  const dirs = new Set<string>();
+  const errno = (code: string, p: string): NodeJS.ErrnoException =>
+    Object.assign(new Error(`${code}: ${p}`), { code });
+
+  return {
+    files,
+    dirs,
+    reset(): void {
+      files.clear();
+      dirs.clear();
+    },
+    readFileSync: vi.fn((p: string): string => {
+      const content = files.get(p);
+      if (content === undefined) {
+        throw errno("ENOENT", p);
+      }
+      return content;
+    }),
+    writeFileSync: vi.fn((p: string, data: string, opts?: { flag?: string }): void => {
+      if (opts?.flag === "wx" && files.has(p)) {
+        throw errno("EEXIST", p);
+      }
+      files.set(p, String(data));
+    }),
+    unlinkSync: vi.fn((p: string): void => {
+      if (!files.delete(p)) {
+        throw errno("ENOENT", p);
+      }
+    }),
+    mkdirSync: vi.fn((p: string): void => {
+      dirs.add(p);
+    }),
+  };
+});
+
+vi.mock("fs", () => ({
+  readFileSync: fsMock.readFileSync,
+  writeFileSync: fsMock.writeFileSync,
+  unlinkSync: fsMock.unlinkSync,
+  mkdirSync: fsMock.mkdirSync,
+}));
+
+import * as path from "path";
+import {
+  LOCK_CHECK_INTERVAL_MS,
+  LOCK_FILE_NAME,
+  isProcessAlive,
+  lockFilePath,
+  readLock,
+  releaseLock,
+  tryAcquireLock,
+} from "../../src/lockFile";
+
+const STORAGE = path.join("/", "storage", "wake-word");
+const LOCK = path.join(STORAGE, LOCK_FILE_NAME);
+
+/** A PID that no operating system will have handed out. */
+const DEAD_PID = 2_147_483_647;
+const OTHER_PID = 4242;
+
+const alive = () => true;
+const dead = () => false;
+
+function plant(lock: unknown): void {
+  fsMock.files.set(LOCK, typeof lock === "string" ? lock : JSON.stringify(lock));
+}
+
+function stored(): { pid: number; startedAt: string } {
+  return JSON.parse(fsMock.files.get(LOCK) ?? "null");
+}
+
+beforeEach(() => {
+  fsMock.reset();
+  fsMock.readFileSync.mockClear();
+  fsMock.writeFileSync.mockClear();
+  fsMock.unlinkSync.mockClear();
+  fsMock.mkdirSync.mockClear();
+});
+
+describe("lockFilePath", () => {
+  it("places the lock inside the storage directory", () => {
+    expect(lockFilePath(STORAGE)).toBe(LOCK);
+    expect(path.basename(lockFilePath(STORAGE))).toBe("wake-word.lock");
+  });
+});
+
+describe("LOCK_CHECK_INTERVAL_MS", () => {
+  it("polls a standing-by window every ten seconds", () => {
+    expect(LOCK_CHECK_INTERVAL_MS).toBe(10_000);
+  });
+});
+
+describe("isProcessAlive", () => {
+  it("is true for this process", () => {
+    expect(isProcessAlive(process.pid)).toBe(true);
+  });
+
+  it("is false for a PID that does not exist", () => {
+    expect(isProcessAlive(DEAD_PID)).toBe(false);
+  });
+
+  it("rejects process-group and malformed PIDs rather than probing them", () => {
+    // kill(0, 0) and kill(-1, 0) address groups and succeed, which would read
+    // as a live lock holder that can never die.
+    expect(isProcessAlive(0)).toBe(false);
+    expect(isProcessAlive(-1)).toBe(false);
+    expect(isProcessAlive(NaN)).toBe(false);
+    expect(isProcessAlive(1.5)).toBe(false);
+  });
+
+  it("treats a process it is not allowed to signal as alive", () => {
+    const spy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+    });
+    try {
+      expect(isProcessAlive(OTHER_PID)).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("treats a process that is gone as dead", () => {
+    const spy = vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("ESRCH"), { code: "ESRCH" });
+    });
+    try {
+      expect(isProcessAlive(OTHER_PID)).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe("readLock", () => {
+  it("reports an absent file", () => {
+    expect(readLock(LOCK)).toEqual({ kind: "absent" });
+  });
+
+  it("reads a well-formed lock", () => {
+    plant({ pid: OTHER_PID, startedAt: "2026-09-05T10:30:00.000Z" });
+    expect(readLock(LOCK)).toEqual({
+      kind: "held",
+      lock: { pid: OTHER_PID, startedAt: "2026-09-05T10:30:00.000Z" },
+    });
+  });
+
+  it("tolerates a missing startedAt", () => {
+    plant({ pid: OTHER_PID });
+    expect(readLock(LOCK)).toEqual({ kind: "held", lock: { pid: OTHER_PID, startedAt: "" } });
+  });
+
+  it("reports malformed JSON as corrupt", () => {
+    plant("{ not json");
+    expect(readLock(LOCK)).toEqual({ kind: "corrupt" });
+  });
+
+  it("reports a lock without a usable pid as corrupt", () => {
+    for (const bad of [{}, { pid: "12" }, { pid: 0 }, { pid: -3 }, { pid: 1.5 }, null, 7, "str"]) {
+      plant(bad);
+      expect(readLock(LOCK), JSON.stringify(bad)).toEqual({ kind: "corrupt" });
+    }
+  });
+
+  it("reports an unreadable file as corrupt rather than absent", () => {
+    plant({ pid: OTHER_PID });
+    fsMock.readFileSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    });
+    expect(readLock(LOCK)).toEqual({ kind: "corrupt" });
+  });
+});
+
+describe("tryAcquireLock", () => {
+  it("succeeds when no lock exists and writes this process's pid", () => {
+    const now = () => new Date("2026-09-05T10:30:00.000Z");
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: alive, now })).toBe(true);
+    expect(stored()).toEqual({ pid: 100, startedAt: "2026-09-05T10:30:00.000Z" });
+  });
+
+  it("creates the storage directory first", () => {
+    tryAcquireLock(LOCK, { ownPid: 100, isAlive: alive });
+    expect(fsMock.mkdirSync).toHaveBeenCalledWith(STORAGE, { recursive: true });
+  });
+
+  it("creates the file exclusively", () => {
+    tryAcquireLock(LOCK, { ownPid: 100, isAlive: alive });
+    expect(fsMock.writeFileSync).toHaveBeenCalledWith(
+      LOCK,
+      expect.any(String),
+      expect.objectContaining({ flag: "wx" })
+    );
+  });
+
+  it("defaults to the real process pid", () => {
+    expect(tryAcquireLock(LOCK)).toBe(true);
+    expect(stored().pid).toBe(process.pid);
+  });
+
+  it("fails when another running process holds the lock", () => {
+    plant({ pid: OTHER_PID, startedAt: "earlier" });
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: alive })).toBe(false);
+    // The holder's lock is left exactly as it was.
+    expect(stored()).toEqual({ pid: OTHER_PID, startedAt: "earlier" });
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+    expect(fsMock.unlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("probes the holder's pid, not its own", () => {
+    plant({ pid: OTHER_PID });
+    const isAlive = vi.fn(() => true);
+    tryAcquireLock(LOCK, { ownPid: 100, isAlive });
+    expect(isAlive).toHaveBeenCalledWith(OTHER_PID);
+  });
+
+  it("takes over a stale lock left by a dead process", () => {
+    plant({ pid: DEAD_PID, startedAt: "long ago" });
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: dead })).toBe(true);
+    expect(stored().pid).toBe(100);
+  });
+
+  it("uses the real liveness probe against a stale lock by default", () => {
+    plant({ pid: DEAD_PID });
+    expect(tryAcquireLock(LOCK, { ownPid: 100 })).toBe(true);
+    expect(stored().pid).toBe(100);
+  });
+
+  it("takes over a lock that is not valid JSON", () => {
+    plant("{ definitely not json");
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: alive })).toBe(true);
+    expect(stored().pid).toBe(100);
+  });
+
+  it("takes over a lock that names no usable pid", () => {
+    plant({ startedAt: "2026-09-05T10:30:00.000Z" });
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: alive })).toBe(true);
+    expect(stored().pid).toBe(100);
+  });
+
+  it("succeeds without rewriting when the lock is already ours", () => {
+    // Listening resumes after every cooldown and start() runs again; the
+    // original startedAt must survive that.
+    plant({ pid: 100, startedAt: "original" });
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: dead })).toBe(true);
+    expect(stored()).toEqual({ pid: 100, startedAt: "original" });
+    expect(fsMock.writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("yields to the window that wins a simultaneous create", () => {
+    // Both windows read "absent". The other one's exclusive create lands
+    // first, so ours fails with EEXIST and we must read again and defer.
+    fsMock.writeFileSync.mockImplementationOnce(() => {
+      plant({ pid: OTHER_PID, startedAt: "won" });
+      throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+    });
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: alive })).toBe(false);
+    expect(stored()).toEqual({ pid: OTHER_PID, startedAt: "won" });
+  });
+
+  it("takes over when the race winner has already died", () => {
+    fsMock.writeFileSync.mockImplementationOnce(() => {
+      plant({ pid: DEAD_PID });
+      throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+    });
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: dead })).toBe(true);
+    expect(stored().pid).toBe(100);
+  });
+
+  it("gives up after losing the create twice", () => {
+    // Pathological: the file keeps reappearing under a pid that reads as
+    // dead. Two passes and out, so the caller is never spun forever.
+    const lose = (): never => {
+      throw Object.assign(new Error("EEXIST"), { code: "EEXIST" });
+    };
+    fsMock.writeFileSync.mockImplementationOnce(lose).mockImplementationOnce(lose);
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: dead })).toBe(false);
+    expect(fsMock.writeFileSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates a write failure that is not a lost race", () => {
+    // An unwritable storage directory is the caller's decision: the
+    // extension logs it and listens without coordination.
+    fsMock.writeFileSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error("EACCES"), { code: "EACCES" });
+    });
+    expect(() => tryAcquireLock(LOCK, { ownPid: 100, isAlive: alive })).toThrow(/EACCES/);
+  });
+
+  it("copes with the stale lock vanishing before it can be removed", () => {
+    plant({ pid: DEAD_PID });
+    // Another window removed the stale file between our read and our unlink.
+    fsMock.unlinkSync.mockImplementationOnce((p: string) => {
+      fsMock.files.delete(p);
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    expect(tryAcquireLock(LOCK, { ownPid: 100, isAlive: dead })).toBe(true);
+    expect(stored().pid).toBe(100);
+  });
+});
+
+describe("releaseLock", () => {
+  it("deletes the lock this process wrote", () => {
+    plant({ pid: 100, startedAt: "x" });
+    releaseLock(LOCK, 100);
+    expect(fsMock.files.has(LOCK)).toBe(false);
+  });
+
+  it("defaults to the real process pid", () => {
+    plant({ pid: process.pid, startedAt: "x" });
+    releaseLock(LOCK);
+    expect(fsMock.files.has(LOCK)).toBe(false);
+  });
+
+  it("leaves another process's lock alone", () => {
+    plant({ pid: OTHER_PID, startedAt: "theirs" });
+    releaseLock(LOCK, 100);
+    expect(stored()).toEqual({ pid: OTHER_PID, startedAt: "theirs" });
+    expect(fsMock.unlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when there is no lock", () => {
+    expect(() => releaseLock(LOCK, 100)).not.toThrow();
+    expect(fsMock.unlinkSync).not.toHaveBeenCalled();
+  });
+
+  it("leaves a corrupt lock in place because ownership cannot be proven", () => {
+    plant("{ not json");
+    expect(() => releaseLock(LOCK, 100)).not.toThrow();
+    expect(fsMock.files.has(LOCK)).toBe(true);
+  });
+
+  it("swallows a delete failure", () => {
+    plant({ pid: 100 });
+    fsMock.unlinkSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error("EPERM"), { code: "EPERM" });
+    });
+    expect(() => releaseLock(LOCK, 100)).not.toThrow();
+  });
+});
+
+describe("acquire and release together", () => {
+  it("models two windows starting, the first closing, the second taking over", () => {
+    // Window A starts and takes the lock.
+    expect(tryAcquireLock(LOCK, { ownPid: 1, isAlive: () => true })).toBe(true);
+
+    // Window B starts while A is alive and stands down.
+    const aAlive = { value: true };
+    const probe = (pid: number) => (pid === 1 ? aAlive.value : false);
+    expect(tryAcquireLock(LOCK, { ownPid: 2, isAlive: probe })).toBe(false);
+
+    // A crashes: its lock is left behind, its pid is gone.
+    aAlive.value = false;
+
+    // B's watcher fires and takes over.
+    expect(tryAcquireLock(LOCK, { ownPid: 2, isAlive: probe })).toBe(true);
+    expect(stored().pid).toBe(2);
+
+    // B disables listening and the lock is gone for the next window.
+    releaseLock(LOCK, 2);
+    expect(readLock(LOCK)).toEqual({ kind: "absent" });
+  });
+
+  it("models the owner disabling listening so the other window can start", () => {
+    expect(tryAcquireLock(LOCK, { ownPid: 1, isAlive: alive })).toBe(true);
+    expect(tryAcquireLock(LOCK, { ownPid: 2, isAlive: alive })).toBe(false);
+    releaseLock(LOCK, 1);
+    expect(tryAcquireLock(LOCK, { ownPid: 2, isAlive: alive })).toBe(true);
+    expect(stored().pid).toBe(2);
+  });
+
+  it("keeps the lock through a cooldown and re-acquire cycle", () => {
+    expect(tryAcquireLock(LOCK, { ownPid: 1, isAlive: alive })).toBe(true);
+    const first = stored();
+    // Cooldown expires, listening resumes, start() asks again.
+    expect(tryAcquireLock(LOCK, { ownPid: 1, isAlive: alive })).toBe(true);
+    expect(stored()).toEqual(first);
+    // The other window still cannot take it.
+    expect(tryAcquireLock(LOCK, { ownPid: 2, isAlive: alive })).toBe(false);
+  });
+});

--- a/tests/unit/sessionStats.test.ts
+++ b/tests/unit/sessionStats.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+import {
+  createSessionStats,
+  formatSessionStats,
+  recordDetection,
+  sessionDurationMinutes,
+} from "../../src/wakeWordCore";
+
+const T0 = 1_700_000_000_000;
+const MINUTE = 60_000;
+
+describe("createSessionStats", () => {
+  it("starts every counter at zero", () => {
+    const stats = createSessionStats(T0);
+    expect(stats.detections).toBe(0);
+    expect(stats.detectionsByPhrase.size).toBe(0);
+    expect(stats.errors).toBe(0);
+    expect(stats.engineStarts).toBe(0);
+    expect(stats.cooldowns).toBe(0);
+  });
+
+  it("stamps the creation time", () => {
+    expect(createSessionStats(T0).startedAt).toBe(T0);
+  });
+
+  it("defaults the creation time to now", () => {
+    const before = Date.now();
+    const stats = createSessionStats();
+    expect(stats.startedAt).toBeGreaterThanOrEqual(before);
+    expect(stats.startedAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("gives each session its own phrase map", () => {
+    const a = createSessionStats(T0);
+    const b = createSessionStats(T0);
+    recordDetection(a, "Claude");
+    expect(b.detectionsByPhrase.size).toBe(0);
+  });
+});
+
+describe("recordDetection", () => {
+  it("increments the total and the per-phrase count", () => {
+    const stats = createSessionStats(T0);
+    recordDetection(stats, "Claude");
+    expect(stats.detections).toBe(1);
+    expect(stats.detectionsByPhrase.get("Claude")).toBe(1);
+  });
+
+  it("keeps a separate count per phrase", () => {
+    const stats = createSessionStats(T0);
+    recordDetection(stats, "Claude");
+    recordDetection(stats, "Copilot");
+    recordDetection(stats, "Claude");
+    expect(stats.detections).toBe(3);
+    expect(stats.detectionsByPhrase.get("Claude")).toBe(2);
+    expect(stats.detectionsByPhrase.get("Copilot")).toBe(1);
+  });
+
+  it("leaves the other counters alone", () => {
+    const stats = createSessionStats(T0);
+    recordDetection(stats, "Claude");
+    expect(stats.errors).toBe(0);
+    expect(stats.engineStarts).toBe(0);
+    expect(stats.cooldowns).toBe(0);
+  });
+});
+
+describe("sessionDurationMinutes", () => {
+  it("reports whole minutes", () => {
+    expect(sessionDurationMinutes(createSessionStats(T0), T0 + 342 * MINUTE)).toBe(342);
+  });
+
+  it("rounds to the nearest minute", () => {
+    const stats = createSessionStats(T0);
+    expect(sessionDurationMinutes(stats, T0 + 342 * MINUTE + 29_000)).toBe(342);
+    expect(sessionDurationMinutes(stats, T0 + 342 * MINUTE + 31_000)).toBe(343);
+  });
+
+  it("is zero for a session shorter than half a minute", () => {
+    expect(sessionDurationMinutes(createSessionStats(T0), T0 + 20_000)).toBe(0);
+  });
+
+  it("never goes negative when the clock steps backwards", () => {
+    expect(sessionDurationMinutes(createSessionStats(T0), T0 - 5 * MINUTE)).toBe(0);
+  });
+
+  it("defaults to now", () => {
+    expect(sessionDurationMinutes(createSessionStats(Date.now()))).toBe(0);
+  });
+});
+
+describe("formatSessionStats", () => {
+  it("renders a session with nothing in it and no phrase breakdown", () => {
+    expect(formatSessionStats(createSessionStats(T0), T0)).toBe(
+      "Session: 0min, 0 detections, 0 errors, 0 engine starts, 0 cooldowns"
+    );
+  });
+
+  it("renders several phrases, most detected first", () => {
+    const stats = createSessionStats(T0);
+    for (let i = 0; i < 2; i++) recordDetection(stats, "Terminal");
+    for (let i = 0; i < 8; i++) recordDetection(stats, "Claude");
+    for (let i = 0; i < 4; i++) recordDetection(stats, "Copilot");
+    stats.engineStarts = 17;
+    stats.cooldowns = 14;
+    expect(formatSessionStats(stats, T0 + 342 * MINUTE)).toBe(
+      "Session: 342min, 14 detections (Claude: 8, Copilot: 4, Terminal: 2), " +
+        "0 errors, 17 engine starts, 14 cooldowns"
+    );
+  });
+
+  it("keeps first-heard order for phrases with equal counts", () => {
+    const stats = createSessionStats(T0);
+    recordDetection(stats, "Terminal");
+    recordDetection(stats, "Claude");
+    expect(formatSessionStats(stats, T0)).toContain("(Terminal: 1, Claude: 1)");
+  });
+
+  it("uses the singular for a count of one", () => {
+    const stats = createSessionStats(T0);
+    recordDetection(stats, "Claude");
+    stats.errors = 1;
+    stats.engineStarts = 1;
+    stats.cooldowns = 1;
+    expect(formatSessionStats(stats, T0 + MINUTE)).toBe(
+      "Session: 1min, 1 detection (Claude: 1), 1 error, 1 engine start, 1 cooldown"
+    );
+  });
+
+  it("counts errors and engine starts independently of detections", () => {
+    const stats = createSessionStats(T0);
+    stats.errors = 2;
+    stats.engineStarts = 3;
+    expect(formatSessionStats(stats, T0)).toBe(
+      "Session: 0min, 0 detections, 2 errors, 3 engine starts, 0 cooldowns"
+    );
+  });
+
+  it("is a single log line", () => {
+    const stats = createSessionStats(T0);
+    recordDetection(stats, "Claude");
+    recordDetection(stats, "Copilot");
+    expect(formatSessionStats(stats, T0)).not.toContain("\n");
+  });
+
+  it("defaults the end time to now", () => {
+    expect(formatSessionStats(createSessionStats(Date.now()))).toMatch(/^Session: 0min, /);
+  });
+});


### PR DESCRIPTION
Only one editor window listens at a time. A PID lock in globalStorage gives ownership to the first window; subsequent windows show "Other window" in the status bar and take over automatically if the owner exits or crashes. The lock is created exclusively, so windows restored together on editor startup cannot both win it.

Add wakeWord.audioDevice setting for selecting a microphone by name substring or device index. Decibri's device option is passed through to Microphone.open(). Errors name the configured device.

Log session statistics (detections per phrase, errors, engine starts, cooldowns, duration) to the output channel on deactivation and before an engine switch resets the counters.

Add integration tests for engine lifecycle with a mock child process, covering state transitions, crash/retry backoff, retry-timer cancellation on stop(), pause(), and start(), and the RELEASED protocol timeout.

Fix stop() leaving a child that had not yet reported READY running, and pause() and start() leaving a crash-backoff retry armed, in both engines. All three were found by the new lifecycle tests.